### PR TITLE
Refer to tag 0.8.1 directly, rather than :latest (which appears to be stale)

### DIFF
--- a/fig.yml
+++ b/fig.yml
@@ -3,7 +3,7 @@ zookeeper:
   ports: 
     - "2181:2181"
 kafka:
-  image: wurstmeister/kafka:latest
+  image: wurstmeister/kafka:0.8.1
   ports:
     - "9092"
   links: 


### PR DESCRIPTION
It looks like index.docker.io is not serving up :latest tags as expected (check out both zookeeper and kafka, below)!  I saw this on a brand new boot2docker install.

> docker images
> REPOSITORY           TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
> wurstmeister/kafka   0.8.1               5e0b97d71e7a        31 minutes ago      475.8 MB
> jplock/zookeeper     3.4.6               36f64d944773        6 weeks ago         317.1 MB
> jplock/zookeeper     3.4.5               3d509edad4d0        3 months ago        333.2 MB
> wurstmeister/kafka   latest              c386c221ba09        6 months ago        484.6 MB
> jplock/zookeeper     latest              9ce81845fa8f        10 months ago       515.6 MB
