### PR TITLE
Allow Kafka config values to contain forward slashes

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,7 +19,7 @@ do
     kafka_name=`echo "$VAR" | sed -r "s/KAFKA_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
     env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
     if egrep -q "(^|^#)$kafka_name" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/(^|^#)($kafka_name)=(.*)/\2=${!env_var}/g" $KAFKA_HOME/config/server.properties
+        sed -r -i "s@(^|^#)($kafka_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/server.properties #note that no config values may contain an '@' char
     else
         echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties
     fi


### PR DESCRIPTION
If the sed delimiter is / then Kafka config values that contain that char are not replaced in server.properties. Several Kafka config values commonly contain slashes, such as log.dirs (e.g., "/var/log/kafka") and zookeeper.connect (e.g., "hostname:2181/kafka"). I couldn't find any common Kafka config values that would contain the @ character.
