### PR TITLE
Allow declaring topics that should be created when the server starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,19 @@ The default ```docker-compose.yml``` should be seen as a starting point. By defa
 
 - ```docker-compose -f docker-compose-single-broker.yml up```
 
+##Automatically create topics
 
+If you want to have kafka-docker automatically create topics in Kafka during
+creation, a ```KAFKA_CREATE_TOPICS``` environment variable can be
+added in ```docker-compose.yml```.
+
+Here is an example snippet from ```docker-compose.yml```:
+
+        environment:
+          KAFKA_CREATE_TOPICS: "Topic1,Topic2"
+
+NOTE: All topics will be created with a single partition and a single replica
+ 
 ##Tutorial
 
 [http://wurstmeister.github.io/kafka-docker/](http://wurstmeister.github.io/kafka-docker/)

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -31,4 +31,16 @@ do
   fi
 done
 
-$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
+
+$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
+KAFKA_SERVER_PID=$!
+
+while netstat -lnt | awk '$4 ~ /:9092$/ {exit 1}'; do sleep 1; done
+
+if [[ -n $KAFKA_CREATE_TOPICS ]]; then
+    IFS=','; for topicToCreate in $KAFKA_CREATE_TOPICS; do
+        $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor 1 --partition 1 --topic "$topicToCreate"
+    done
+fi
+
+wait $KAFKA_SERVER_PID


### PR DESCRIPTION
In my use of kafka-docker, I found it useful to be able to declare which topics should exist in the server in the fig.yml file.  The attached changes allow you to add an environment variable "KAFKA_CREATE_TOPICS" to define a list of topics that should be created like this:

```
  environment:
    KAFKA_ADVERTISED_HOST_NAME: 192.168.59.103
    KAFKA_CREATE_TOPICS: "topic1,topic2"
```

It currently defaults to a replication factor of 1 and a single partition because that worked for me.  If you like this type of improvement to kafka-docker, I'd be willing to do a little more work to get it merged in.  Also, I can add documentation for the new environment variable if you are interested in merging this.