### PR TITLE
fix injection of jvm heap options

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -14,7 +14,7 @@ if [[ -z "$KAFKA_ZOOKEEPER_CONNECT" ]]; then
 fi
 
 if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
-    sed -r -i "s/^(export KAFKA_HEAP_OPTS)=\"(.*)\"/\1=\"$KAFKA_HEAP_OPTS\"/g" $KAFKA_HOME/bin/kafka-server-start.sh
+    sed -r -i "s/(export KAFKA_HEAP_OPTS)=\"(.*)\"/\1=\"$KAFKA_HEAP_OPTS\"/g" $KAFKA_HOME/bin/kafka-server-start.sh
     unset KAFKA_HEAP_OPTS
 fi
 


### PR DESCRIPTION
The 0.8.2 release of Kafka moved the KAFKA_HEAP_OPTS export into an if clause, preventing this regex from injecting the external override.