### PR TITLE
Fixes an issue that occurred during download of kafka

### DIFF
--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | sed -rn 's/.*"preferred":.*"(.*)"/\1/p')
+mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
 url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"


### PR DESCRIPTION
Specifically, when the `download-kafka.sh` was being run, it created a mirror URL that was had `}` appended to it. For example I was getting a mirror like `http://apache.tsl.gr/}` instead of `http://apache.tsl.gr/`

This PR replaces sed with the `jq` utility (already present in  the image) to extract the mirror