### PR TITLE
Enable autoconfigure KAFKA_ADVERTISED_HOST_NAME

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -18,6 +18,10 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
+if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
+    export KAFKA_ADVERTISED_HOST_NAME=$(route -n | awk '/UG[ \t]/{print $2}')
+fi
+
 for VAR in `env`
 do
   if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then


### PR DESCRIPTION
Enable Kafka to autoconfigure its advertised hostname with local ip address if it is not set.