### PR TITLE
Using hostname to get container ip

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,7 +19,7 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
 fi
 
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
-    export KAFKA_ADVERTISED_HOST_NAME=$(route -n | awk '/UG[ \t]/{print $2}')
+    export KAFKA_ADVERTISED_HOST_NAME=$(hostname -i)
 fi
 
 for VAR in `env`


### PR DESCRIPTION
`route` was used to extract the ip address for the container to auto-configure `KAFKA_ADVERTISED_HOST_NAME`.  Unfortunately, that didn't seem to be grabbing the correct IP.

For example, the IP for this container is `169.254.7.150`:

```
root@7cd2d90c2c47:/# ifconfig
eth0      Link encap:Ethernet  HWaddr 02:42:a9:fe:07:96
          inet addr:169.254.7.150  Bcast:0.0.0.0  Mask:255.255.240.0
          inet6 addr: fe80::42:a9ff:fefe:796/64 Scope:Link
          UP BROADCAST RUNNING  MTU:1500  Metric:1
          RX packets:412 errors:0 dropped:0 overruns:0 frame:0
          TX packets:616 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:41469 (41.4 KB)  TX bytes:49174 (49.1 KB)

lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          inet6 addr: ::1/128 Scope:Host
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:3424 errors:0 dropped:0 overruns:0 frame:0
          TX packets:3424 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:171348 (171.3 KB)  TX bytes:171348 (171.3 KB)
```

The can be fetched using the `hostname` command really easily.

```
root@7cd2d90c2c47:/# hostname -i
169.254.7.150
```

The existing `route` command will return the gateway, which isn't necessarily appropriate here.

```
root@7cd2d90c2c47:/# route -n
Kernel IP routing table
Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
0.0.0.0         169.254.1.1     0.0.0.0         UG    0      0        0 eth0
169.254.0.0     0.0.0.0         255.255.240.0   U     0      0        0 eth0
root@7cd2d90c2c47:/# route -n | awk '/UG[ \t]/{print $2}'
169.254.1.1
```

This is nice for when you want to run multiple kafka containers on a host, but cannot share `/var/run/docker.sock` with the container.  In that use case, it's difficult to use dynamic port assignment, but relatively easy to get the containers IP address from within the container.