### PR TITLE
Limit waiting time to avoid hanging container when kafka fails to start

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -39,7 +39,15 @@ done
 $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
 KAFKA_SERVER_PID=$!
 
-while netstat -lnt | awk '$4 ~ /:9092$/ {exit 1}'; do sleep 1; done
+wait_timeout=600
+count=0
+while netstat -lnt | awk '$4 ~ /:9092$/ {exit 1}'; do
+    sleep 1;
+    count=$(expr $count + 1)
+    if [ $count -gt $wait_timeout ]; then
+        break
+    fi
+done
 
 if [[ -n $KAFKA_CREATE_TOPICS ]]; then
     IFS=','; for topicToCreate in $KAFKA_CREATE_TOPICS; do

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -40,8 +40,8 @@ $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
 KAFKA_SERVER_PID=$!
 
 
-if [[ -z "$KAFKA_START_WAIT_TIMEOUT" ]]; then
-    KAFKA_START_WAIT_TIMEOUT=600
+if [[ -z "$START_TIMEOUT" ]]; then
+    START_TIMEOUT=600
 fi
 
 start_timeout_exceeded=false
@@ -49,13 +49,13 @@ count=0
 while netstat -lnt | awk '$4 ~ /:9092$/ {exit 1}'; do
     sleep 1;
     count=$(expr $count + 1)
-    if [ $count -gt $KAFKA_START_WAIT_TIMEOUT ]; then
+    if [ $count -gt $START_TIMEOUT ]; then
         start_timeout_exceeded=true
         break
     fi
 done
 if $start_timeout_exceeded; then
-    echo "Could not start Kafka broker $KAFKA_BROKER_ID (waited for $KAFKA_START_WAIT_TIMEOUT sec)"
+    echo "Could not start Kafka broker (waited for $START_TIMEOUT sec)"
     exit 1
 fi
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -39,15 +39,25 @@ done
 $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
 KAFKA_SERVER_PID=$!
 
-wait_timeout=600
+
+if [[ -z "$KAFKA_START_WAIT_TIMEOUT" ]]; then
+    KAFKA_START_WAIT_TIMEOUT=600
+fi
+
+start_timeout_exceeded=false
 count=0
 while netstat -lnt | awk '$4 ~ /:9092$/ {exit 1}'; do
     sleep 1;
     count=$(expr $count + 1)
-    if [ $count -gt $wait_timeout ]; then
+    if [ $count -gt $KAFKA_START_WAIT_TIMEOUT ]; then
+        start_timeout_exceeded=true
         break
     fi
 done
+if $start_timeout_exceeded; then
+    echo "Could not start Kafka broker $KAFKA_BROKER_ID (waited for $KAFKA_START_WAIT_TIMEOUT sec)"
+    exit 1
+fi
 
 if [[ -n $KAFKA_CREATE_TOPICS ]]; then
     IFS=','; for topicToCreate in $KAFKA_CREATE_TOPICS; do


### PR DESCRIPTION
When Kafka fails to start (for example, if Zookeeper isn't accessible for some reason), the [loop for waiting it to start](https://github.com/wurstmeister/kafka-docker/blob/4063777543eaef8d18691f2d0fe06915896b1788/start-kafka.sh#L42) can go on forever.

This PR proposes a limit of 10 minutes for that loop.

Does this look good?