### PR TITLE
Graceful shutdown of Kafka container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ VOLUME ["/kafka"]
 ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ADD start-kafka.sh /usr/bin/start-kafka.sh
 ADD broker-list.sh /usr/bin/broker-list.sh
-CMD start-kafka.sh
+
+# Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
+CMD ["start-kafka.sh"]

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -35,6 +35,8 @@ do
   fi
 done
 
+# Capture kill requests to stop properly
+trap "$KAFKA_HOME/bin/kafka-server-stop.sh; echo 'Kafka stopped.'; exit" SIGHUP SIGINT SIGTERM
 
 $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
 KAFKA_SERVER_PID=$!


### PR DESCRIPTION
Without this, running `docker-compose stop` doesn't stop Kafka properly (timeout after 10sec and killed -9) and starting again with `docker-compose up -d` results in Kafka issuing errors because previous run didn't unregister from ZK:
```
FATAL Fatal error during KafkaServerStartable startup. Prepare to shutdown (kafka.server.KafkaServerStartable)
java.lang.RuntimeException: A broker is already registered on the path /brokers/ids/1. This probably indicates that you either have configured a brokerid that is already in use, or else you have shutdown this broker and restarted it faster than the zookeeper timeout so it appears to be re-registering.
```