### PR TITLE
Revert "Enable autoconfigure KAFKA_ADVERTISED_HOST_NAME"

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -18,10 +18,6 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
-    export KAFKA_ADVERTISED_HOST_NAME=$(route -n | awk '/UG[ \t]/{print $2}')
-fi
-
 for VAR in `env`
 do
   if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then


### PR DESCRIPTION
Reverts commit 4063777543eaef8d18691f2d0fe06915896b1788.

`KAFKA_ADVERTISED_HOST_NAME` shouldn't be autoconfigured since the use case of it is user dependent. For example:

1. Only Kafka instance in docker network
2. Both Kafka instance and client exists in docker network with docker link

Automatically set `KAFKA_ADVERTISED_HOST_NAME` to host address in docker network making it difficult to support the 2nd use case, which is a common case using docker-compose.