### PR TITLE
Enable usage in cloud

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:trusty
-
-MAINTAINER Wurstmeister 
+MAINTAINER mweliczko 
 
 ENV KAFKA_VERSION="0.8.2.1" SCALA_VERSION="2.10"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,4 @@ ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ADD start-kafka.sh /usr/bin/start-kafka.sh
 ADD broker-list.sh /usr/bin/broker-list.sh
 ADD kafka.conf /etc/supervisor/conf.d/
-RUN echo command=$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties >> /etc/supervisor/conf.d/kafka.conf
 CMD start-kafka.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 
-MAINTAINER Wurstmeister 
+MAINTAINER mweliczko 
 
 ENV KAFKA_VERSION="0.8.2.1" SCALA_VERSION="2.10"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:trusty
 
-MAINTAINER mweliczko 
+MAINTAINER Wurstmeister 
 
 ENV KAFKA_VERSION="0.8.2.1" SCALA_VERSION="2.10"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:trusty
-MAINTAINER mweliczko 
+
+MAINTAINER Wurstmeister 
 
 ENV KAFKA_VERSION="0.8.2.1" SCALA_VERSION="2.10"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Wurstmeister
 
 ENV KAFKA_VERSION="0.8.2.1" SCALA_VERSION="2.10"
 
-RUN apt-get update && apt-get install -y unzip openjdk-6-jdk wget curl git docker.io jq
+RUN apt-get update && apt-get install -y supervisor unzip openjdk-6-jdk wget curl git docker.io jq
 
 ADD download-kafka.sh /tmp/download-kafka.sh
 RUN /tmp/download-kafka.sh
@@ -15,4 +15,5 @@ VOLUME ["/kafka"]
 ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ADD start-kafka.sh /usr/bin/start-kafka.sh
 ADD broker-list.sh /usr/bin/broker-list.sh
+ADD kafka.conf /etc/supervisor/conf.d/
 CMD start-kafka.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ADD start-kafka.sh /usr/bin/start-kafka.sh
 ADD broker-list.sh /usr/bin/broker-list.sh
 ADD kafka.conf /etc/supervisor/conf.d/
+RUN echo command=$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties >> /etc/supervisor/conf.d/kafka.conf
 CMD start-kafka.sh

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The default ```docker-compose.yml``` should be seen as a starting point. By defa
 
 If you don't specify a broker id in your docker-compose file, it will automatically be generated based on the name that docker-compose gives the container. This allows scaling up and down. In this case it is recommended to use the ```--no-recreate``` option of docker-compose to ensure that containers are not re-created and thus keep their names and ids.
 
+If a broker id cannot be calculated with the above method, one will be generated as a function of nanoseconds since epoch and a random number. This has the problems outlined [here](https://kafka.apache.org/082/ops.html#basic_ops_cluster_expansion), but at least Kafka will be able to start.
+
 
 ##Automatically create topics
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The image is available directly from https://registry.hub.docker.com/
 
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 - modify the ```KAFKA_ADVERTISED_HOST_NAME``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
+- or use ```ADVERTISED_HOST_NAME_SCRIPT``` to specify how to calculate the ```KAFKA_ADVERTISED_HOST_NAME```. This is very useful for situations where you won't know your server name until launching the Docker container. For example, running as an Amazon EC2 instance, ```curl -s http://169.254.169.254/latest/meta-data/public-hostname```
 - if you want to customise any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
 
 ##Usage

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
 url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-wget -v "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
 url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+wget -v "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"

--- a/kafka.conf
+++ b/kafka.conf
@@ -1,4 +1,3 @@
 [program:kafka]
-command=$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
 autostart=true
 autorestart=true

--- a/kafka.conf
+++ b/kafka.conf
@@ -1,0 +1,4 @@
+[program:kafka]
+command=$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
+autostart=true
+autorestart=true

--- a/kafka.conf
+++ b/kafka.conf
@@ -1,4 +1,3 @@
 [program:kafka]
-command=/opt/kafka_2.10-0.8.2.1/bin/kafka-server-start.sh /opt/kafka_2.10-0.8.2.1/config/server.properties
 autostart=true
 autorestart=true

--- a/kafka.conf
+++ b/kafka.conf
@@ -1,3 +1,4 @@
 [program:kafka]
+command=/opt/kafka_2.10-0.8.2.1/bin/kafka-server-start.sh /opt/kafka_2.10-0.8.2.1/config/server.properties
 autostart=true
 autorestart=true

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -26,9 +26,9 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     sed -r -i "s/(export KAFKA_HEAP_OPTS)=\"(.*)\"/\1=\"$KAFKA_HEAP_OPTS\"/g" $KAFKA_HOME/bin/kafka-server-start.sh
     unset KAFKA_HEAP_OPTS
 fi
-if [[ -n "$KAFKA_ADVERTISED_HOST_NAME_SCRIPT" ]]; then
-	echo AboutToCalculateHostNameUsing $KAFKA_ADVERTISED_HOST_NAME_SCRIPT
-    export KAFKA_ADVERTISED_HOST_NAME=$(eval $KAFKA_ADVERTISED_HOST_NAME_SCRIPT)
+if [[ -n "$ADVERTISED_HOST_NAME_SCRIPT" ]]; then
+	echo AboutToCalculateHostNameUsing $ADVERTISED_HOST_NAME_SCRIPT
+    export KAFKA_ADVERTISED_HOST_NAME=$(eval $ADVERTISED_HOST_NAME_SCRIPT)
 	echo UsedScriptToCalculatedHostNameAs $KAFKA_ADVERTISED_HOST_NAME
 fi
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -6,6 +6,13 @@ fi
 if [[ -z "$KAFKA_BROKER_ID" ]]; then
     export KAFKA_BROKER_ID=$(docker inspect `hostname` | jq --raw-output '.[0] | .Name' | awk -F_ '{print $3}')
 fi
+if [[ -z "$KAFKA_BROKER_ID" ]]; then
+    uniqueNumber=$(date +%s%3N)
+	((uniqueNumber=uniqueNumber-1447000000000))
+	((uniqueNumber=uniqueNumber+$RANDOM))
+	echo SettingKafkaBrokerIdTo $uniqueNumber
+    export KAFKA_BROKER_ID=$uniqueNumber
+fi
 if [[ -z "$KAFKA_LOG_DIRS" ]]; then
     export KAFKA_LOG_DIRS="/kafka/kafka-logs-$KAFKA_BROKER_ID"
 fi
@@ -19,7 +26,7 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
 fi
 
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
-    export KAFKA_ADVERTISED_HOST_NAME=$(route -n | awk '/UG[ \t]/{print $2}')
+    export KAFKA_ADVERTISED_HOST_NAME=$(curl -s http://169.254.169.254/latest/meta-data/public-hostname)
 fi
 
 for VAR in `env`

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -19,14 +19,18 @@ fi
 if [[ -z "$KAFKA_ZOOKEEPER_CONNECT" ]]; then
     export KAFKA_ZOOKEEPER_CONNECT=$(env | grep ZK.*PORT_2181_TCP= | sed -e 's|.*tcp://||' | paste -sd ,)
 fi
-
 if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     sed -r -i "s/(export KAFKA_HEAP_OPTS)=\"(.*)\"/\1=\"$KAFKA_HEAP_OPTS\"/g" $KAFKA_HOME/bin/kafka-server-start.sh
     unset KAFKA_HEAP_OPTS
 fi
-
+if [[ -n "$KAFKA_ADVERTISED_HOST_NAME_SCRIPT" ]]; then
+	echo AboutToCalculateHostNameUsing $KAFKA_ADVERTISED_HOST_NAME_SCRIPT
+    export KAFKA_ADVERTISED_HOST_NAME=$(eval $KAFKA_ADVERTISED_HOST_NAME_SCRIPT)
+	echo UsedScriptToCalculatedHostNameAs $KAFKA_ADVERTISED_HOST_NAME
+fi
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
-    export KAFKA_ADVERTISED_HOST_NAME=$(curl -s http://169.254.169.254/latest/meta-data/public-hostname)
+    export KAFKA_ADVERTISED_HOST_NAME=$(route -n | awk '/UG[ \t]/{print $2}')
+	echo UsedRouteToCalculatedHostNameAs $KAFKA_ADVERTISED_HOST_NAME
 fi
 
 for VAR in `env`


### PR DESCRIPTION
While running a Kafka cluster in an autoscaling cloud environment, it is not always possible to specify some critical Kafka settings in advance.

- broker.id: This must be unique per instance. When creating a cluster (specifically AWS), it is difficult to specify a unique identifier per server in advance. Therefore, calculate one dynamically if all else fails.
- advertised.host.name: When publishing to Kafka, the publisher must be able to contact a server directly, even if it is behind a load balancer. Therefore, the advertised host name must be addressable by the publisher. In AWS, this can be calculated with a script like ```curl -s http://169.254.169.254/latest/meta-data/public-hostname```

