### PR TITLE
Bump Kafka version to 0.9.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Wurstmeister
 
 RUN apk add --update unzip wget curl docker jq coreutils
 
-ENV KAFKA_VERSION="0.9.0.0" SCALA_VERSION="2.11"
+ENV KAFKA_VERSION="0.9.0.1" SCALA_VERSION="2.11"
 ADD download-kafka.sh /tmp/download-kafka.sh
 RUN /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 


### PR DESCRIPTION
Hi, recently there was an update for Kafka to 0.9.0.1 that fixes several bugs.

http://www.confluent.io/blog/announcing-apache-kafka-0.9.0.1-and-confluent-platform-2.0.1

The image can be tested from here: https://hub.docker.com/r/chriszen/kafka/

Would you consider to update the docker image ?