### PR TITLE
Replace Boot2Docker with Docker Toolbox.

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,9 @@ $ $KAFKA_HOME/bin/kafka-console-producer.sh --topic=topic \
 <h1>
 <a id="running-kafka-docker-on-a-mac" class="anchor" href="#running-kafka-docker-on-a-mac" aria-hidden="true"><span class="octicon octicon-link"></span></a>Running kafka-docker on a Mac:</h1>
 
-<p>Use <a href="http://boot2docker.io/">Boot2Docker</a></p>
+<p>Install the <a href="https://www.docker.com/products/docker-toolbox">Docker Toolbox</a>.</p>
+
+<p>Set <code>KAFKA_ADVERTISED_HOST_NAME</code> to the IP that is returned by the <code>docker-machine ip</code> command.</p>
 
 <h1>
 <a id="troubleshooting" class="anchor" href="#troubleshooting" aria-hidden="true"><span class="octicon octicon-link"></span></a>Troubleshooting:</h1>


### PR DESCRIPTION
Also, add info about setting the advertised host name, since it took me a bit of digging to figure it out.

I just updated the generated `index.html` to highlight the changes I wanted to make. Note that [params.json](https://github.com/wurstmeister/kafka-docker/blob/gh-pages/params.json) is not updated.

I tried to use the "Page Editor" UI from the Github settings, but that [made a mess](https://github.com/scribu/kafka-docker/commit/4147d1904a9db174c39f7b663eb68430282b696b). So yeah, it's not very PR friendly.