### PR TITLE
moved docker host ip address to an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The image is available directly from https://registry.hub.docker.com/
 ##Pre-Requisites
 
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
-- modify the ```KAFKA_ADVERTISED_HOST_NAME``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
+- set the environment variable `DOCKER_HOST_IP_ADDR` to match the docker host IP (NOTE: do not use localhost or 127.0.0.1); you can run:
+```
+export DOCKER_HOST_IP_ADDR=$(docker-machine ip default)
+```
 - if you want to customise any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
 
 ##Usage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ kafka:
   links: 
     - zookeeper:zk
   environment:
-    KAFKA_ADVERTISED_HOST_NAME: 192.168.59.103
+    KAFKA_ADVERTISED_HOST_NAME: ${DOCKER_HOST_IP_ADDR}
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
My docker vm had a different IP address, so I had to change the compose file.  Now that it is an environment variable, I no longer need to modify the file.