### PR TITLE
Missing configuration (KAFKA_ADVERTISED_PORT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The image is available directly from https://registry.hub.docker.com/
 ##Pre-Requisites
 
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
-- modify the ```KAFKA_ADVERTISED_HOST_NAME``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
+- modify the ```KAFKA_ADVERTISED_HOST_NAME``` & ```DOCKER_HOST``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
 - if you want to customise any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
 
 ##Usage

--- a/docker-compose-single-broker.yml
+++ b/docker-compose-single-broker.yml
@@ -10,6 +10,7 @@ kafka:
     - zookeeper:zk
   environment:
     KAFKA_ADVERTISED_HOST_NAME: 192.168.59.103
+    KAFKA_ADVERTISED_PORT: 9092
     KAFKA_CREATE_TOPICS: "test:1:1"
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ kafka:
     - zookeeper:zk
   environment:
     KAFKA_ADVERTISED_HOST_NAME: 192.168.59.103
-    KAFKA_ADVERTISED_PORT: 9092
     DOCKER_HOST: 192.168.59.103:2375
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ kafka:
     - zookeeper:zk
   environment:
     KAFKA_ADVERTISED_HOST_NAME: 192.168.59.103
+    KAFKA_ADVERTISED_PORT: 9092
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ kafka:
   environment:
     KAFKA_ADVERTISED_HOST_NAME: 192.168.59.103
     KAFKA_ADVERTISED_PORT: 9092
+    DOCKER_HOST: 192.168.59.103:2375
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Closes wurstmeister/kafka-docker#81