### PR TITLE
Don't store `KAFKA_JMX_OPTS` into server.properties

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -29,12 +29,14 @@ fi
 for VAR in `env`
 do
   if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
-    kafka_name=`echo "$VAR" | sed -r "s/KAFKA_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
-    env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
-    if egrep -q "(^|^#)$kafka_name=" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s@(^|^#)($kafka_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/server.properties #note that no config values may contain an '@' char
-    else
-        echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties
+    if [[ ! $VAR =~ ^KAFKA_JMX_OPTS ]]; then
+        kafka_name=`echo "$VAR" | sed -r "s/KAFKA_(.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+        env_var=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
+        if egrep -q "(^|^#)$kafka_name=" $KAFKA_HOME/config/server.properties; then
+            sed -r -i "s@(^|^#)($kafka_name)=(.*)@\2=${!env_var}@g" $KAFKA_HOME/config/server.properties #note that no config values may contain an '@' char
+        else
+            echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties
+        fi
     fi
   fi
 done


### PR DESCRIPTION
When `KAFKA_JMX_OPTS` env variable is specified it should not be stored into server.properties config file.
