### PR TITLE
pull request for exposing jmx port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,3 @@ ADD create-topics.sh /usr/bin/create-topics.sh
 
 # Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
 CMD ["start-kafka.sh"]
-EXPOSE ${KAFKA_JMX_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ ADD create-topics.sh /usr/bin/create-topics.sh
 
 # Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
 CMD ["start-kafka.sh"]
+EXPOSE ${KAFKA_JMX_PORT}

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -43,4 +43,4 @@ done
 trap "$KAFKA_HOME/bin/kafka-server-stop.sh; echo 'Kafka stopped.'; exit" SIGHUP SIGINT SIGTERM
 
 create-topics.sh & 
-$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
+JMX_PORT=$KAFKA_JMX_PORT $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties


### PR DESCRIPTION
please checkout start-kafka.sh , 
exported the jmx port only for kafka-server-start.sh script

issue described here : http://qnalist.com/questions/6215113/port-already-in-use-error-when-trying-to-add-topic