### PR TITLE
added Amazone ECS support to auto discover advertised host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ When using commands, make sure you review the "Variable Substitution" section in
 
 If ```KAFKA_ADVERTISED_HOST_NAME``` is specified, it takes presendence over ```HOSTNAME_COMMAND```
 
+For AWS deployment, you can use the Metadata service to get the container host's IP:
+```
+HOSTNAME_COMMAND=wget -t3 -T2 -qO-  http://169.254.169.254/latest/meta-data/local-ipv4
+```
+Reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
 ##Tutorial
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -22,6 +22,13 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
+if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
+    # on Amazon ECS, we can get the host from the metadata service
+    # reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+    # for non-EC2 hosts, wget will retry indefinitely, so we have timeouts set
+    export KAFKA_ADVERTISED_HOST_NAME=$(wget -t3 -T2 -qO-  http://169.254.169.254/latest/meta-data/local-ipv4)
+fi
+
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" && -n "$HOSTNAME_COMMAND" ]]; then
     export KAFKA_ADVERTISED_HOST_NAME=$(eval $HOSTNAME_COMMAND)
 fi

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -22,13 +22,6 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" ]]; then
-    # on Amazon ECS, we can get the host from the metadata service
-    # reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-    # for non-EC2 hosts, wget will retry indefinitely, so we have timeouts set
-    export KAFKA_ADVERTISED_HOST_NAME=$(wget -t3 -T2 -qO-  http://169.254.169.254/latest/meta-data/local-ipv4)
-fi
-
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME" && -n "$HOSTNAME_COMMAND" ]]; then
     export KAFKA_ADVERTISED_HOST_NAME=$(eval $HOSTNAME_COMMAND)
 fi


### PR DESCRIPTION
Using http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html, I can get the host ip address.  For non-ec2 docker hosts, this will fall back to default behavior.