### PR TITLE
specify port mapping to avoid random host port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 zookeeper:
   image: wurstmeister/zookeeper
   ports: 
-    - "2181"
+    - "2181:2181"
 kafka:
   build: .
   ports:
-    - "9092"
+    - "9092:9092"
   links: 
     - zookeeper:zk
   environment:


### PR DESCRIPTION
Without mapping, we have to run `docker-compose ps` to find out the port of zookeeper, which would be used for $ZK later on. We can avoid this little annoying thing by explicitly specifying the port mapping. #17 