### PR TITLE
Replication factor is 3 by default, preventing single-broker

### DIFF
--- a/docker-compose-single-broker.yml
+++ b/docker-compose-single-broker.yml
@@ -12,5 +12,6 @@ services:
       KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
       KAFKA_CREATE_TOPICS: "test:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Kafka defaults to replication factor of 3 for the topic __consumer_offsets (even if __consumer_offsets:1:1 is created on launch) preventing single-broker from accepting any consumers (since the number of replicas won't match)