### PR TITLE
Assigns permissions to scripts after adding.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,18 @@ RUN apk add --update unzip wget curl docker jq coreutils
 
 ENV KAFKA_VERSION="0.10.0.0" SCALA_VERSION="2.11"
 ADD download-kafka.sh /tmp/download-kafka.sh
+RUN chmod a+x /tmp/download-kafka.sh
 RUN /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 
 VOLUME ["/kafka"]
 
 ENV KAFKA_HOME /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION}
 ADD start-kafka.sh /usr/bin/start-kafka.sh
+RUN chmod a+x /usr/bin/start-kafka.sh
 ADD broker-list.sh /usr/bin/broker-list.sh
+RUN chmod a+x /usr/bin/broker-list.sh
 ADD create-topics.sh /usr/bin/create-topics.sh
+RUN chmod a+x /usr/bin/create-topics.sh
 
 # Use "exec" form so that it runs as PID 1 (useful for graceful shutdown)
 CMD ["start-kafka.sh"]


### PR DESCRIPTION
When running on Windows, it appears that after *.sh files are added to the container, they don't have execute permissions (even though they do on the host machine). This commit explicitly assigns the permissions.
