### PR TITLE
Upgrade to 0.10.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Wurstmeister
 
 RUN apk add --update unzip wget curl docker jq coreutils
 
-ENV KAFKA_VERSION="0.10.0.0" SCALA_VERSION="2.11"
+ENV KAFKA_VERSION="0.10.0.1" SCALA_VERSION="2.11"
 ADD download-kafka.sh /tmp/download-kafka.sh
 RUN /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
 


### PR DESCRIPTION
Kafka 0.10.0.1 includes a [Zookeeper fix][] which handles DNS cache invalidation during connection errors. This allows a rolling migration of Zookeeper nodes to different underlying IP addresses.

[Zookeeper fix]: https://issues.apache.org/jira/browse/KAFKA-3838