### PR TITLE
Bash script wait for KAFKA process

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -60,8 +60,8 @@ term_handler() {
 
 # Capture kill requests to stop properly
 trap "term_handler" SIGHUP SIGINT SIGTERM
-create-topics.sh & 
+create-topics.sh &
 $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
 KAFKA_PID=$!
 
-wait
+wait "$KAFKA_PID"


### PR DESCRIPTION
The container has to terminate if the java process terminates; 
Not waiting for the java process is making the container wait 
for the "create-topic.sh" timeout. even if there's no kafka process.