### PR TITLE
Don't default ADVERTISED_PORT if listeners are configured

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -3,7 +3,9 @@
 if [[ -z "$KAFKA_PORT" ]]; then
     export KAFKA_PORT=9092
 fi
-if [[ -z "$KAFKA_ADVERTISED_PORT" ]]; then
+if [[ -z "$KAFKA_ADVERTISED_PORT" && \
+  -z "$KAFKA_LISTENERS" && \
+  -z "$KAFKA_ADVERTISED_LISTENERS" ]]; then
     export KAFKA_ADVERTISED_PORT=$(docker port `hostname` $KAFKA_PORT | sed -r "s/.*:(.*)/\1/g")
 fi
 if [[ -z "$KAFKA_BROKER_ID" ]]; then


### PR DESCRIPTION
If configuring listeners (and/or advertised.listeners) to support a
configuration with both PLAINTEXT and SSL endpoints[1], you must not set either
of advertised.{host,port}, otherwise the broker will only create the PLAINTEXT
endpoint.

[1]: http://docs.confluent.io/2.0.0/kafka/incremental-security-upgrade.html

I wasn't sure how to format this, so please let me know if you prefer it
differently. Also, would it be possible to back-port this to the latest 0.9
tag?