### PR TITLE
Bug fix 'returned a non-zero code: 4' error.

### DIFF
--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -2,4 +2,4 @@
 
 mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
 url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
-wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"  --user-agent="User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:32.0) Gecko/20100101 Firefox/32.0"


### PR DESCRIPTION
Bug fix 'returned a non-zero code: 4' when 'docker-compose up -d'. Failing 'wget' causes the the non-zero code:4, add --user-agent option at download-kafka.sh script.