### PR TITLE
Change how create-topics.sh checks for running Kafka

### DIFF
--- a/create-topics.sh
+++ b/create-topics.sh
@@ -8,7 +8,17 @@ fi
 start_timeout_exceeded=false
 count=0
 step=10
-while netstat -lnt | awk '$4 ~ /:'$KAFKA_PORT'$/ {exit 1}'; do
+
+check_kafka_running() {
+    if [[ "$KAFKA_BROKER_ID" != "-1" ]]; then
+        echo dump | nc -w 1 "$KAFKA_ZOOKEEPER_CONNECT" $KAFKA_PORT \
+            | grep -F "/brokers/ids/$KAFKA_BROKER_ID"
+    else
+        netstat -lnt | awk '{ print $4 }' | grep ":$KAFKA_PORT"
+    fi
+}
+
+while ! check_kafka_running; do
     echo "waiting for kafka to be ready"
     sleep $step;
     count=$(expr $count + $step)


### PR DESCRIPTION
It seems in Kafka 0.8, the port is bound early in the process of starting up the server (I saw this happening in `network_mode: host`, which may have something to do with it), so sometimes `create-topics.sh` will proceed to start creating the topics before the Kafka server is up, which causes errors. If the broker ID is set, then a perhaps more reliable way to check that the server is up and running is to check that the ephemeral ZooKeeper node `/brokers/ids/<ID>` exists. This is the node that Kafka uses to check the health of other brokers in the cluster, so if the node is there, then that indicates the broker is up and healthy. If the broker ID is not set, then unfortunately, there doesn't appear to be a reliable way to check which broker ID was assigned, so checking for port binding is a reasonable fallback. Maybe another option in this case is just grepping the server logs for a line that looks like

```
[2017-01-28 20:57:19,354] INFO [Kafka Server 0], started (kafka.server.KafkaServer)
```

which is kind of hacky, but may still be more reliable.