### PR TITLE
jmx-support: Fix start script so sub-process is not created

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ HOSTNAME_COMMAND=wget -t3 -T2 -qO-  http://169.254.169.254/latest/meta-data/loca
 ```
 Reference: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
+## JMX
+
+For monitoring purposes you may wish to configure JMX. Additional to the standard JMX parameters, problems could arise from the underlying RMI protocol used to connect
+
+* java.rmi.server.hostname - interface to bind listening port
+* com.sun.management.jmxremote.rmi.port - The port to service RMI requests
+
+For example, to connect to a kafka running locally (assumes exposing port 1099)
+
+      KAFKA_JMX_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.rmi.port=1099"
+      JMX_PORT: 1099
+
+Jconsole can now connect at ```jconsole 192.168.99.100:1099```
+
 ##Tutorial
 
 [http://wurstmeister.github.io/kafka-docker/](http://wurstmeister.github.io/kafka-docker/)

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -63,7 +63,7 @@ term_handler() {
 # Capture kill requests to stop properly
 trap "term_handler" SIGHUP SIGINT SIGTERM
 create-topics.sh &
-$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
+exec $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties &
 KAFKA_PID=$!
 
 wait "$KAFKA_PID"


### PR DESCRIPTION
This makes environment variables available to the kafka-server-start.sh script. This allows JMX_PORT
and other options to be set, and allow the correct configuration of JMX

Change-Id: If1434b5a3fb9d094cd5943656e8a38d9bc60d1e7