### PR TITLE
docker-compose file for Docker Swarm mode

### DIFF
--- a/docker-compose-stack.yml
+++ b/docker-compose-stack.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
docker-compose file that will work with Docker stack deployment as per Docker v1.13 and above.
Due to the load-balancing and service discovery features  of Docker Swarm mode in Docker v1.13, we can safely expose the Kafka port and point the ADVERTISED_HOST to any one of the docker hosts in the Swarm cluster.
