### PR TITLE
use container name instead of hostname when we call docker port

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+if [[ -z "$KAFKA_IMG_NAME" ]]; then
+    export KAFKA_IMG_NAME=wurstmeister/kafka
+fi
+
 if [[ -z "$KAFKA_PORT" ]]; then
     export KAFKA_PORT=9092
 fi
 if [[ -z "$KAFKA_ADVERTISED_PORT" && \
   -z "$KAFKA_LISTENERS" && \
   -z "$KAFKA_ADVERTISED_LISTENERS" ]]; then
-    export KAFKA_ADVERTISED_PORT=$(docker port `hostname` $KAFKA_PORT | sed -r "s/.*:(.*)/\1/g")
+    export CONTAINER_NAME=$(docker ps | grep $KAFKA_IMG_NAME | awk '{print $NF;}')
+    export KAFKA_ADVERTISED_PORT=$(docker port "$CONTAINER_NAME" $KAFKA_PORT | sed -r "s/.*:(.*)/\1/g")
 fi
 if [[ -z "$KAFKA_BROKER_ID" ]]; then
     # By default auto allocate broker ID


### PR DESCRIPTION
I'm opening this to see if I can get some help.
I feel like I'm in the final stage of getting this to work.
#170 is fixed with this change, but when I connect a kafkacat consumer from the host machine (my laptop) I get

```
% ERROR: Topic <TOPIC_NAME> error: Broker: Leader not available
```

Here is the docker-compose service definition I'm using:

```
zookeeper:
    image: confluent/zookeeper
    ports:
      - "2181"

  kafka:
    hostname: kafka
    image: bsorahan/kafka
    environment:
      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
      KAFKA_IMG_NAME: bsorahan/kafka
    ports:
      - "9092"
    depends_on:
      - zookeeper
    links:
      - zookeeper
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
```

And here is copy/pasta from the kafka container logs

```
kafka_1      | [2017-03-03 21:30:38,782] INFO Initiating client connection, connectString=zookeeper:2181 sessionTimeout=6000 watcher=org.I0Itec.zkclient.ZkClient@62150f9e (org.apache.zookeeper.ZooKeeper)
kafka_1      | [2017-03-03 21:30:38,825] INFO Waiting for keeper state SyncConnected (org.I0Itec.zkclient.ZkClient)
kafka_1      | [2017-03-03 21:30:38,831] INFO Opening socket connection to server reportdefservice_zookeeper_1.reportdefservice_default/172.19.0.2:2181. Will not attempt to authenticate using SASL (unknown error) (org.apache.zookeeper.ClientCnxn)
kafka_1      | [2017-03-03 21:30:38,851] INFO Socket connection established to reportdefservice_zookeeper_1.reportdefservice_default/172.19.0.2:2181, initiating session (org.apache.zookeeper.ClientCnxn)
kafka_1      | [2017-03-03 21:30:39,053] INFO Session establishment complete on server reportdefservice_zookeeper_1.reportdefservice_default/172.19.0.2:2181, sessionid = 0x15a9614dcf60000, negotiated timeout = 6000 (org.apache.zookeeper.ClientCnxn)
kafka_1      | [2017-03-03 21:30:39,055] INFO zookeeper state changed (SyncConnected) (org.I0Itec.zkclient.ZkClient)
kafka_1      | [2017-03-03 21:30:39,520] INFO Cluster ID = QVSbMV4XT6eJ6sA_LbH8Iw (kafka.server.KafkaServer)
kafka_1      | [2017-03-03 21:30:39,609] INFO Log directory '/kafka/kafka-logs-kafka' not found, creating it. (kafka.log.LogManager)
kafka_1      | [2017-03-03 21:30:39,655] INFO Loading logs. (kafka.log.LogManager)
kafka_1      | [2017-03-03 21:30:39,678] INFO Logs loading complete in 23 ms. (kafka.log.LogManager)
kafka_1      | [2017-03-03 21:30:39,829] INFO Starting log cleanup with a period of 300000 ms. (kafka.log.LogManager)
kafka_1      | [2017-03-03 21:30:39,838] INFO Starting log flusher with a default period of 9223372036854775807 ms. (kafka.log.LogManager)
kafka_1      | [2017-03-03 21:30:39,893] WARN No meta.properties file under dir /kafka/kafka-logs-kafka/meta.properties (kafka.server.BrokerMetadataCheckpoint)
kafka_1      | [2017-03-03 21:30:40,068] INFO Awaiting socket connections on 0.0.0.0:9092. (kafka.network.Acceptor)
kafka_1      | [2017-03-03 21:30:40,079] INFO [Socket Server on Broker 1001], Started 1 acceptor threads (kafka.network.SocketServer)
kafka_1      | [2017-03-03 21:30:40,148] INFO [ExpirationReaper-1001], Starting  (kafka.server.DelayedOperationPurgatory$ExpiredOperationReaper)
kafka_1      | [2017-03-03 21:30:40,152] INFO [ExpirationReaper-1001], Starting  (kafka.server.DelayedOperationPurgatory$ExpiredOperationReaper)
kafka_1      | [2017-03-03 21:30:40,277] INFO Creating /controller (is it secure? false) (kafka.utils.ZKCheckedEphemeral)
kafka_1      | [2017-03-03 21:30:40,311] INFO Result of znode creation is: OK (kafka.utils.ZKCheckedEphemeral)
kafka_1      | [2017-03-03 21:30:40,313] INFO 1001 successfully elected as leader (kafka.server.ZookeeperLeaderElector)
kafka_1      | [2017-03-03 21:30:40,595] INFO [ExpirationReaper-1001], Starting  (kafka.server.DelayedOperationPurgatory$ExpiredOperationReaper)
kafka_1      | [2017-03-03 21:30:40,611] INFO [ExpirationReaper-1001], Starting  (kafka.server.DelayedOperationPurgatory$ExpiredOperationReaper)
kafka_1      | [2017-03-03 21:30:40,612] INFO [ExpirationReaper-1001], Starting  (kafka.server.DelayedOperationPurgatory$ExpiredOperationReaper)
kafka_1      | [2017-03-03 21:30:40,651] INFO [GroupCoordinator 1001]: Starting up. (kafka.coordinator.GroupCoordinator)
kafka_1      | [2017-03-03 21:30:40,657] INFO [GroupCoordinator 1001]: Startup complete. (kafka.coordinator.GroupCoordinator)
kafka_1      | [2017-03-03 21:30:40,669] INFO [Group Metadata Manager on Broker 1001]: Removed 0 expired offsets in 7 milliseconds. (kafka.coordinator.GroupMetadataManager)
kafka_1      | [2017-03-03 21:30:40,713] INFO Will not load MX4J, mx4j-tools.jar is not in the classpath (kafka.utils.Mx4jLoader$)
kafka_1      | [2017-03-03 21:30:40,840] INFO Creating /brokers/ids/1001 (is it secure? false) (kafka.utils.ZKCheckedEphemeral)
kafka_1      | [2017-03-03 21:30:40,909] INFO Result of znode creation is: OK (kafka.utils.ZKCheckedEphemeral)
kafka_1      | [2017-03-03 21:30:40,923] INFO Registered broker 1001 at path /brokers/ids/1001 with addresses: PLAINTEXT -> EndPoint(kafka,32892,PLAINTEXT) (kafka.utils.ZkUtils)
kafka_1      | [2017-03-03 21:30:40,937] WARN No meta.properties file under dir /kafka/kafka-logs-kafka/meta.properties (kafka.server.BrokerMetadataCheckpoint)
kafka_1      | [2017-03-03 21:30:41,108] INFO New leader is 1001 (kafka.server.ZookeeperLeaderElector$LeaderChangeListener)
kafka_1      | [2017-03-03 21:30:41,149] INFO Kafka version : 0.10.1.1 (org.apache.kafka.common.utils.AppInfoParser)
kafka_1      | [2017-03-03 21:30:41,159] INFO Kafka commitId : f10ef2720b03b247 (org.apache.kafka.common.utils.AppInfoParser)
kafka_1      | [2017-03-03 21:30:41,166] INFO [Kafka Server 1001], started (kafka.server.KafkaServer)
```