### PR TITLE
Corrected heading formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Dockerfile for [Apache Kafka](http://kafka.apache.org/)
 
 The image is available directly from [Docker Hub](https://hub.docker.com/r/wurstmeister/kafka/)
 
-##Pre-Requisites
+## Pre-Requisites
 
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 - modify the ```KAFKA_ADVERTISED_HOST_NAME``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
 - if you want to customise any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
 
-##Usage
+## Usage
 
 Start a cluster:
 
@@ -29,18 +29,18 @@ Destroy a cluster:
 
 - ```docker-compose stop```
 
-##Note
+## Note
 
 The default ```docker-compose.yml``` should be seen as a starting point. By default each broker will get a new port number and broker id on restart. Depending on your use case this might not be desirable. If you need to use specific ports and broker ids, modify the docker-compose configuration accordingly, e.g. [docker-compose-single-broker.yml](https://github.com/wurstmeister/kafka-docker/blob/master/docker-compose-single-broker.yml):
 
 - ```docker-compose -f docker-compose-single-broker.yml up```
 
-##Broker IDs
+## Broker IDs
 
 If you don't specify a broker id in your docker-compose file, it will automatically be generated (see [https://issues.apache.org/jira/browse/KAFKA-1070](https://issues.apache.org/jira/browse/KAFKA-1070). This allows scaling up and down. In this case it is recommended to use the ```--no-recreate``` option of docker-compose to ensure that containers are not re-created and thus keep their names and ids.
 
 
-##Automatically create topics
+## Automatically create topics
 
 If you want to have kafka-docker automatically create topics in Kafka during
 creation, a ```KAFKA_CREATE_TOPICS``` environment variable can be
@@ -53,7 +53,7 @@ Here is an example snippet from ```docker-compose.yml```:
 
 ```Topic 1``` will have 1 partition and 3 replicas, ```Topic 2``` will have 1 partition, 1 replica and a `cleanup.policy` set to `compact`.
 
-##Advertised hostname
+## Advertised hostname
 
 You can configure the advertised hostname in different ways
 
@@ -84,6 +84,6 @@ For example, to connect to a kafka running locally (assumes exposing port 1099)
 
 Jconsole can now connect at ```jconsole 192.168.99.100:1099```
 
-##Tutorial
+## Tutorial
 
 [http://wurstmeister.github.io/kafka-docker/](http://wurstmeister.github.io/kafka-docker/)


### PR DESCRIPTION
Missing spaces meant that level 2 headings in the README.md were not being rendered properly, This PR just adds those spaces after the double hash for level 2 headings.