### PR TITLE
Accept BROKER_ID_COMMAND env var for setting broker.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ The default ```docker-compose.yml``` should be seen as a starting point. By defa
 
 ## Broker IDs
 
+You can configure the broker id in different ways
+
+1. explicitly, using ```KAFKA_BROKER_ID```
+2. via a command, using ```BROKER_ID_COMMAND```, e.g. ```BROKER_ID_COMMAND: "hostname | awk -F'-' '{print $2}'"```
+
 If you don't specify a broker id in your docker-compose file, it will automatically be generated (see [https://issues.apache.org/jira/browse/KAFKA-1070](https://issues.apache.org/jira/browse/KAFKA-1070). This allows scaling up and down. In this case it is recommended to use the ```--no-recreate``` option of docker-compose to ensure that containers are not re-created and thus keep their names and ids.
 
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -9,8 +9,12 @@ if [[ -z "$KAFKA_ADVERTISED_PORT" && \
     export KAFKA_ADVERTISED_PORT=$(docker port `hostname` $KAFKA_PORT | sed -r "s/.*:(.*)/\1/g")
 fi
 if [[ -z "$KAFKA_BROKER_ID" ]]; then
-    # By default auto allocate broker ID
-    export KAFKA_BROKER_ID=-1
+    if [[ -n "BROKER_ID_COMMAND" ]]; then
+        export KAFKA_BROKER_ID=$(eval $BROKER_ID_COMMAND)
+    else
+        # By default auto allocate broker ID
+        export KAFKA_BROKER_ID=-1
+    fi
 fi
 if [[ -z "$KAFKA_LOG_DIRS" ]]; then
     export KAFKA_LOG_DIRS="/kafka/kafka-logs-$HOSTNAME"


### PR DESCRIPTION
BROKER_ID_COMMAND works the same way as HOSTNAME_COMMAND, allowing you
to set broker.id via a command that gets evaluated by the startup
script.

This is useful for extracting the broker.id from the hostname when running in environments like Kubernetes.