### PR TITLE
map LOG4J_% env vars to entries in log4j.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The image is available directly from [Docker Hub](https://hub.docker.com/r/wurst
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 - modify the ```KAFKA_ADVERTISED_HOST_NAME``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
 - if you want to customize any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
+- Kafka's log4j usage can be customized by adding environment variables prefixed with ```LOG4J_```. These will be mapped to ```log4j.properties```. For example: ```LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER=DEBUG, authorizerAppender```
 
 ## Usage
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -43,6 +43,16 @@ do
         echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties
     fi
   fi
+
+  if [[ $VAR =~ ^LOG4J_ ]]; then
+    log4j_name=`echo "$VAR" | sed -r "s/(LOG4J_.*)=.*/\1/g" | tr '[:upper:]' '[:lower:]' | tr _ .`
+    log4j_env=`echo "$VAR" | sed -r "s/(.*)=.*/\1/g"`
+    if egrep -q "(^|^#)$log4j_name=" $KAFKA_HOME/config/log4j.properties; then
+        sed -r -i "s@(^|^#)($log4j_name)=(.*)@\2=${!log4j_env}@g" $KAFKA_HOME/config/log4j.properties #note that no config values may contain an '@' char
+    else
+        echo "$log4j_name=${!log4j_env}" >> $KAFKA_HOME/config/log4j.properties
+    fi
+  fi
 done
 
 if [[ -n "$CUSTOM_INIT_SCRIPT" ]] ; then


### PR DESCRIPTION
I took the existing KAFKA_% env var map for config.properties and applied it to log4j.properties

Seems to work for me for tweaking log4j outputs/verbosity (particularly debugging the kafka authorizer), but I'm not very familiar with log4j so it may not work for absolutely every situation

e.g.

```
LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER=DEBUG, authorizerAppender
```

fixes #120 