### PR TITLE
Allow cross building kafka for various archs

### DIFF
--- a/Dockerfile.crossbuild
+++ b/Dockerfile.crossbuild
@@ -12,11 +12,10 @@ ENV KAFKA_VERSION=$kafka_version \
     PATH=${PATH}:${KAFKA_HOME}/bin
 
 COPY download-kafka.sh start-kafka.sh broker-list.sh create-topics.sh /tmp/
-RUN mkdir -p /opt
 RUN apk add --update unzip wget curl docker jq coreutils bash \
  && chmod a+x /tmp/*.sh && sync \
  && mv /tmp/start-kafka.sh /tmp/broker-list.sh /tmp/create-topics.sh /usr/bin \
- && /tmp/download-kafka.sh \
+ && /tmp/download-kafka.sh && mkdir -p /opt \
  && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt \
  && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz \
  && ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} /opt/kafka \

--- a/Dockerfile.crossbuild
+++ b/Dockerfile.crossbuild
@@ -1,4 +1,5 @@
-FROM anapsix/alpine-java
+FROM BASEIMAGE
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
 ARG kafka_version=1.0.0
 ARG scala_version=2.12
@@ -11,9 +12,9 @@ ENV KAFKA_VERSION=$kafka_version \
     PATH=${PATH}:${KAFKA_HOME}/bin
 
 COPY download-kafka.sh start-kafka.sh broker-list.sh create-topics.sh /tmp/
-
-RUN apk add --update unzip wget curl docker jq coreutils \
- && chmod a+x /tmp/*.sh \
+RUN mkdir -p /opt
+RUN apk add --update unzip wget curl docker jq coreutils bash \
+ && chmod a+x /tmp/*.sh && sync \
  && mv /tmp/start-kafka.sh /tmp/broker-list.sh /tmp/create-topics.sh /usr/bin \
  && /tmp/download-kafka.sh \
  && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+.PHONY: build
+ARCH ?= amd64
+QEMUVERSION=v2.9.1
+TEMP_DIR:=$(shell mktemp -d)
+BUILD_IMAGE ?= wurstmeister/kafka-docker:1.0.0
+
+ifeq ($(ARCH),amd64)
+        BASEIMAGE?=anapsix/alpine-java
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=openjdk:jdk-alpine
+        QEMUARCH=ppc64le
+        BUILD_IMAGE = wurstmeister/kafka-docker-$(ARCH):1.0.0
+endif
+
+build: 
+
+ifeq ($(ARCH),amd64)
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+                | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "/CROSS_BUILD_COPY/d" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	# We just build it using the usual process.
+	docker build -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+else
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.crossbuild \
+ 	        | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+                | sed "s|ARCH|$(QEMUARCH)|g" \
+                > $(TEMP_DIR)/Dockerfile.crossbuild
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
+	docker build -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+ 
+endif

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ ifeq ($(ARCH),amd64)
 	cat Dockerfile.crossbuild \
                 | sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
                 | sed "/CROSS_BUILD_COPY/d" \
-                > $(TEMP_DIR)/Dockerfile.crossbuild
+                > $(TEMP_DIR)/Dockerfile
 	# We just build it using the usual process.
-	docker build -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	docker build -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 else
@@ -46,8 +46,8 @@ else
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
 	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.crossbuild > $(TEMP_DIR)/Dockerfile.crossbuild.tmp
-	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.crossbuild
-	docker build -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.crossbuild $(TEMP_DIR)
+	mv $(TEMP_DIR)/Dockerfile.crossbuild.tmp $(TEMP_DIR)/Dockerfile.$(ARCH)
+	docker build -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.$(ARCH) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
  
 endif


### PR DESCRIPTION
This commit introduces a way by which we can now build multi-arch
docker images of kakfa. This patch provides an initial framework
based on some inspiration from:
https://github.com/kubernetes/kubernetes/tree/master/build/debian-base

This patch will allow you to build a cross platform image on an
amd64 machine.

Usage:

     `make build` ==> Retains the old behavior of builds
     `make build ARCH=ppc64le` ==> Builds it for a specific arch

We can further include s390x and arm as other platforms.
Further we can use the manifest-tool or the latest docker client
to push manifest images to dockerhub.