### PR TITLE
Add initial travis ci config with a single kafkacat based test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+
+language: java
+
+services:
+  - docker
+
+install:
+  - docker --version
+  - docker-compose --version
+  - docker build -t wurstmeister/kafka .
+
+before_script:
+  - docker-compose -f test/docker-compose.yml up -d kafka zookeeper
+  - docker-compose -f test/docker-compose.yml scale kafka=2
+
+script:
+  - sleep 5 # Wait for containers to start
+  - export BROKER_LIST=$(./test/internal-broker-list.sh)
+  - docker-compose -f test/docker-compose.yml run tests
+
+after_script:
+  - docker-compose stop

--- a/test/Readme.md
+++ b/test/Readme.md
@@ -1,0 +1,14 @@
+Tests
+=====
+
+This directory contains some basic tests to validate functionality after building.
+
+To execute
+----------
+
+```
+cd test
+docker-compose up -d zookeeper kafka
+docker-compose scale kafka=2    # or however many nodes you want
+BROKER_LIST=$(./internal-broker-list.sh) docker-compose run tests
+```

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  tests:
+    image: confluentinc/cp-kafkacat
+    environment:
+      BROKER_LIST: ${BROKER_LIST}
+    volumes:
+      - .:/tests
+    working_dir: /tests
+    entrypoint:
+      - ./runTests.sh

--- a/test/internal-broker-list.sh
+++ b/test/internal-broker-list.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+CONTAINERS=$(docker inspect -f '{{ .NetworkSettings.Networks.test_default.IPAddress  }}' test_kafka_1 test_kafka_2 | awk '{printf "%s:9092\n", $1}' | tr '\n' ',')
+echo ${CONTAINERS%,}

--- a/test/runTests.sh
+++ b/test/runTests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+runAll() {
+  for t in $(ls test-*.sh); do
+    echo "testing '$t'"
+    ( source $t )
+    status=$?
+    if [[ -z "$status" || ! "$status" -eq 0 ]]; then
+      return $status
+    fi
+  done
+
+  return $?
+}
+
+runAll
+result=$?
+echo "exit status $result"
+exit $result

--- a/test/test-001-read-write.sh
+++ b/test/test-001-read-write.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+testReadWrite() {
+	echo 'foo,bar' | kafkacat -b "$BROKER_LIST" -P -D, -t readwrite
+	kafkacat -b "$BROKER_LIST" -C -e -t readwrite
+	return 0
+}
+
+testReadWrite


### PR DESCRIPTION
Eventually we might need to switch to something a little easier for more complex tests, such as Java/Go/Python based tests. But kafkacat and bash should be sufficient for initial smoke tests.