### PR TITLE
Explicitly add Zookeeper dependencies for Kafka in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The image is available directly from [Docker Hub](https://hub.docker.com/r/wurst
 
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 - modify the ```KAFKA_ADVERTISED_HOST_NAME``` in ```docker-compose.yml``` to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
+- Zookeeper running instance. It can be retrieved from [wurstmeister/zookeeper](https://hub.docker.com/r/wurstmeister/zookeeper/).
 - if you want to customize any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
 - Kafka's log4j usage can be customized by adding environment variables prefixed with ```LOG4J_```. These will be mapped to ```log4j.properties```. For example: ```LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER=DEBUG, authorizerAppender```
 


### PR DESCRIPTION
If you start this image with `docker-compose` and you don't have a running instance of Zookeeper, Kafka will go in exception due to unavailability of Zookeeper terminating the service.

E.g. exception:
```
 FATAL Fatal error during KafkaServer startup. Prepare to shutdown (kafka.server.KafkaServer)
kafka_1       | org.I0Itec.zkclient.exception.ZkTimeoutException: Unable to connect to zookeeper server ''
```