### PR TITLE
Support Docker for Mac native

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,12 @@ See the included sample compose file ```docker-compose-swarm.yml```
 ## Tutorial
 
 [http://wurstmeister.github.io/kafka-docker/](http://wurstmeister.github.io/kafka-docker/)
+
+## Docker OSX Native
+
+Use the docker-compose-osx-native.yaml to start your containers. This docker-compose file uses the docker.for.mac.localhost network feature from docker.
+
+To connect to the kafka container: 
+`./start-kafka-shell-osx-native.sh kafka zookeeper:2181 kafkadocker_default`
+
+This script accepts a third argument that to set the docker network to connect to. This allows you to use the named containers from the docker-compose and alleviates the issues with kafka not reaching zookeeper when creating topics with the kafka scripts. 

--- a/docker-compose-osx-native.yaml
+++ b/docker-compose-osx-native.yaml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    build: .
+    ports:
+      - "9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: docker.for.mac.localhost
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/start-kafka-shell-osx-native.sh
+++ b/start-kafka-shell-osx-native.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e HOST_IP=$1 -e ZK=$2 --net=$3 -i -t wurstmeister/kafka /bin/bash


### PR DESCRIPTION
Added two files to fix issues with using docker for mac. 

The new compose yaml uses the docker.for.mac.localhost to configure the KAFKA_ADVERTISED_HOST_NAME.
The new start-kafka-shell script accepts a third option to connect to the network generated by the compose yaml. This connects the container, created in the shell script, to the network generated by docker-compose. It allows you to use the docker-compose service names in the start-kafka-shell script instead of the container ip addresses. 

Resolves #110 
