### PR TITLE
Update kafka 10 to newer alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@ FROM anapsix/alpine-java
 
 MAINTAINER Wurstmeister 
 
-RUN apk add --update unzip wget curl docker jq coreutils
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.7/main" > /etc/apk/repositories && \
+    apk update && \
+    apk add --update unzip wget curl jq coreutils
 
 ENV KAFKA_VERSION="0.10.0.0" SCALA_VERSION="2.11"
 ADD download-kafka.sh /tmp/download-kafka.sh
-RUN /tmp/download-kafka.sh && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
+RUN /tmp/download-kafka.sh && \
+    tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt && \
+    rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz && \
+    rm -rf /var/cache/apk/*
 
 VOLUME ["/kafka"]
 

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-mirror=$(curl --stderr /dev/null https://www.apache.org/dyn/closer.cgi\?as_json\=1 | jq -r '.preferred')
+mirror="https://archive.apache.org/dist/"
 url="${mirror}kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
 wget -q "${url}" -O "/tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"


### PR DESCRIPTION
Motivation - current version doesn't use /etc/resolv.conf which prevents
kubernetes usage with the current image.

See https://github.com/gliderlabs/docker-alpine/issues/8