### PR TITLE
Add PORT_COMMAND support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+04-Apr-2018
+-----------
+
+-	Support `_{PORT_COMMAND}` placeholder.
+
 03-Apr-2018
 -----------
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ If you require the value of `HOSTNAME_COMMAND` in any of your other `KAFKA_XXX` 
 KAFKA_ADVERTISED_LISTENERS=SSL://_{HOSTNAME_COMMAND}:9093,PLAINTEXT://9092
 ```
 
+## Advertised port
+
+If the required advertised port is not static, it may be necessary to determine this programatically. This can be done with the `PORT_COMMAND` environment variable.
+
+```
+PORT_COMMAND: "docker port $$(hostname) 9092/tcp | cut -d: -f2
+```
+
+This can be then interpolated in any other `KAFKA_XXX` config using the `_{PORT_COMMAND}` string, i.e.
+
+```
+KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://1.2.3.4:_{PORT_COMMAND}
+```
+
 ## Listener Configuration
 
 It may be useful to have the [Kafka Documentation](https://kafka.apache.org/documentation/) open, to understand the various broker listener configuration options.

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -46,8 +46,17 @@ if [[ -n "$HOSTNAME_COMMAND" ]]; then
     # Replace any occurences of _{HOSTNAME_COMMAND} with the value
     for VAR in $(env); do
         if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{HOSTNAME_COMMAND}" ]]; then
-            # shellcheck disable=SC2163
-            export "${VAR//_\{HOSTNAME_COMMAND\}/$HOSTNAME_VALUE}"
+            eval "export ${VAR//_\{HOSTNAME_COMMAND\}/$HOSTNAME_VALUE}"
+        fi
+    done
+fi
+
+if [[ -n "$PORT_COMMAND" ]]; then
+    PORT_VALUE=$(eval "$PORT_COMMAND")
+    # Replace any occurences of _{PORT_COMMAND} with the value
+    for VAR in $(env); do
+        if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{PORT_COMMAND}" ]]; then
+	    eval "export ${VAR//_\{PORT_COMMAND\}/$PORT_VALUE}"
         fi
     done
 fi

--- a/test/test.start-kafka-port-command.kafka.sh
+++ b/test/test.start-kafka-port-command.kafka.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+source test.functions
+
+testPortCommand() {
+	# Given a port command is provided
+	export PORT_COMMAND='f() { echo "12345"; }; f'
+	export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://1.2.3.4:_{PORT_COMMAND}"
+	export KAFKA_LISTENERS="PLAINTEXT://:9092"
+
+	# When the script is invoked
+	source "$START_KAFKA"
+
+	# Then the configuration uses the value from the command
+	assertExpectedConfig 'advertised.listeners=PLAINTEXT://1.2.3.4:12345'
+	assertExpectedConfig 'listeners=PLAINTEXT://:9092'
+	assertAbsent 'advertised.host.name'
+	assertAbsent 'advertised.port'
+}
+
+testPortCommand


### PR DESCRIPTION
facilitates multiple broker deployment using current advertised.listener config