### PR TITLE
docker-compose-swarm.yml has the wrong container name for kafka

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafka:
-    image: kafka:latest
+    image: wurstmeister/kafka:latest
     ports:
       - target: 9094
         published: 9094

--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafka:
-    image: ${REPO}kafka-docker:latest
+    image: ${REPO}kafka:latest
     ports:
       - target: 9094
         published: 9094

--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafka:
-    image: ${REPO}kafka:latest
+    image: kafka:latest
     ports:
       - target: 9094
         published: 9094


### PR DESCRIPTION
It read ${REPO}kafka-docker instead of ${REPO}kafka