### PR TITLE
[BUG] Evaluate each env var as a single value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+11-Apr-2018
+-----------
+
+-	Issue #313 - Fix parsing of environment value substitution when spaces included.
+
 08-Apr-2018
 -----------
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Store original IFS config, so we can restore it at various stages
+ORIG_IFS=$IFS
+
 if [[ -z "$KAFKA_ZOOKEEPER_CONNECT" ]]; then
     echo "ERROR: missing mandatory config: KAFKA_ZOOKEEPER_CONNECT"
     exit 1
@@ -40,32 +43,31 @@ if [[ -n "$KAFKA_HEAP_OPTS" ]]; then
     unset KAFKA_HEAP_OPTS
 fi
 
-# (#313) Make sure `env` is evaluated as separate entries
-ORIG_IFS=$IFS
-IFS=$'\n'
-
 if [[ -n "$HOSTNAME_COMMAND" ]]; then
     HOSTNAME_VALUE=$(eval "$HOSTNAME_COMMAND")
 
     # Replace any occurences of _{HOSTNAME_COMMAND} with the value
+    IFS=$'\n'
     for VAR in $(env); do
         if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{HOSTNAME_COMMAND}" ]]; then
             eval "export ${VAR//_\{HOSTNAME_COMMAND\}/$HOSTNAME_VALUE}"
         fi
     done
+    IFS=$ORIG_IFS
 fi
 
 if [[ -n "$PORT_COMMAND" ]]; then
     PORT_VALUE=$(eval "$PORT_COMMAND")
+
     # Replace any occurences of _{PORT_COMMAND} with the value
+    IFS=$'\n'
     for VAR in $(env); do
         if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{PORT_COMMAND}" ]]; then
 	    eval "export ${VAR//_\{PORT_COMMAND\}/$PORT_VALUE}"
         fi
     done
+    IFS=$ORIG_IFS
 fi
-
-IFS=$ORIG_IFS
 
 if [[ -n "$RACK_COMMAND" && -z "$KAFKA_BROKER_RACK" ]]; then
     KAFKA_BROKER_RACK=$(eval "$RACK_COMMAND")
@@ -91,30 +93,32 @@ fi
 #Issue newline to config file in case there is not one already
 echo "" >> "$KAFKA_HOME/config/server.properties"
 
-# Read in env as a new-line separated array. This handles the case of env variables have spaces and/or carriage returns. See #313
-IFS=$'\n'; for VAR in $(env)
-do
-  if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
-    kafka_name=$(echo "$VAR" | sed -r 's/KAFKA_(.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-    env_var=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
-    if grep -E -q '(^|^#)'"$kafka_name=" "$KAFKA_HOME/config/server.properties"; then
-        sed -r -i 's@(^|^#)('"$kafka_name"')=(.*)@\2='"${!env_var}"'@g' "$KAFKA_HOME/config/server.properties" #note that no config values may contain an '@' char
-    else
-        echo "$kafka_name=${!env_var}" >> "$KAFKA_HOME/config/server.properties"
-    fi
-  fi
+(
+    # Read in env as a new-line separated array. This handles the case of env variables have spaces and/or carriage returns. See #313
+    IFS=$'\n'
+    for VAR in $(env)
+    do
+      if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
+        kafka_name=$(echo "$VAR" | sed -r 's/KAFKA_(.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
+        env_var=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
+        if grep -E -q '(^|^#)'"$kafka_name=" "$KAFKA_HOME/config/server.properties"; then
+            sed -r -i 's@(^|^#)('"$kafka_name"')=(.*)@\2='"${!env_var}"'@g' "$KAFKA_HOME/config/server.properties" #note that no config values may contain an '@' char
+        else
+            echo "$kafka_name=${!env_var}" >> "$KAFKA_HOME/config/server.properties"
+        fi
+      fi
 
-  if [[ $VAR =~ ^LOG4J_ ]]; then
-    log4j_name=$(echo "$VAR" | sed -r 's/(LOG4J_.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-    log4j_env=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
-    if grep -E -q '(^|^#)'"$log4j_name=" "$KAFKA_HOME/config/log4j.properties"; then
-        sed -r -i 's@(^|^#)('"$log4j_name"')=(.*)@\2='"${!log4j_env}"'@g' "$KAFKA_HOME/config/log4j.properties" #note that no config values may contain an '@' char
-    else
-        echo "$log4j_name=${!log4j_env}" >> "$KAFKA_HOME/config/log4j.properties"
-    fi
-  fi
-done
-IFS=$ORIG_IFS
+      if [[ $VAR =~ ^LOG4J_ ]]; then
+        log4j_name=$(echo "$VAR" | sed -r 's/(LOG4J_.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
+        log4j_env=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
+        if grep -E -q '(^|^#)'"$log4j_name=" "$KAFKA_HOME/config/log4j.properties"; then
+            sed -r -i 's@(^|^#)('"$log4j_name"')=(.*)@\2='"${!log4j_env}"'@g' "$KAFKA_HOME/config/log4j.properties" #note that no config values may contain an '@' char
+        else
+            echo "$log4j_name=${!log4j_env}" >> "$KAFKA_HOME/config/log4j.properties"
+        fi
+      fi
+    done
+)
 
 if [[ -n "$CUSTOM_INIT_SCRIPT" ]] ; then
   eval "$CUSTOM_INIT_SCRIPT"

--- a/test/test.start-kafka-bug-313-kafka-opts.kafka.sh
+++ b/test/test.start-kafka-bug-313-kafka-opts.kafka.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+source test.functions
+
+testKafkaOpts() {
+    # Given required settings are provided
+    export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://:9092"
+    export KAFKA_LISTENERS="PLAINTEXT://:9092"
+    # .. and a CUSTOM_INIT_SCRIPT with spaces
+    export CUSTOM_INIT_SCRIPT="export KAFKA_OPTS=-Djava.security.auth.login.config=/kafka_server_jaas.conf"
+
+    # When the script is invoked
+    source "$START_KAFKA"
+
+    # Then the custom init script should be evaluated
+    if [[ ! "$KAFKA_OPTS" == "-Djava.security.auth.login.config=/kafka_server_jaas.conf" ]]; then
+        echo "KAFKA_OPTS not set to expected value. $KAFKA_OPTS"
+        exit 1
+    fi
+
+    echo "  > Set KAFKA_OPTS=$KAFKA_OPTS"
+}
+
+testKafkaOpts


### PR DESCRIPTION
currently we keep the standard IFS, which means we can split on spaces + carriage returns,
This is mainly problematic for any env var that has a reference to <space>KAFKA as this
will get interpreted as it's own new env var.

Fixes #313
Allows work-around for #312