### PR TITLE
Fix regex when parsing env vars

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -99,18 +99,18 @@ echo "" >> "$KAFKA_HOME/config/server.properties"
     for VAR in $(env)
     do
       if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
-        kafka_name=$(echo "$VAR" | sed -r 's/KAFKA_(.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-        env_var=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
+        kafka_name=$(echo "$VAR" | sed -r 's/KAFKA_([^=]*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
+        kafka_env=$(echo "$VAR" | sed -r 's/([^=]*)=.*/\1/g')
         if grep -E -q '(^|^#)'"$kafka_name=" "$KAFKA_HOME/config/server.properties"; then
-            sed -r -i 's@(^|^#)('"$kafka_name"')=(.*)@\2='"${!env_var}"'@g' "$KAFKA_HOME/config/server.properties" #note that no config values may contain an '@' char
+            sed -r -i 's@(^|^#)('"$kafka_name"')=(.*)@\2='"${!kafka_env}"'@g' "$KAFKA_HOME/config/server.properties" #note that no config values may contain an '@' char
         else
-            echo "$kafka_name=${!env_var}" >> "$KAFKA_HOME/config/server.properties"
+            echo "$kafka_name=${!kafka_env}" >> "$KAFKA_HOME/config/server.properties"
         fi
       fi
 
       if [[ $VAR =~ ^LOG4J_ ]]; then
-        log4j_name=$(echo "$VAR" | sed -r 's/(LOG4J_.*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-        log4j_env=$(echo "$VAR" | sed -r 's/(.*)=.*/\1/g')
+        log4j_name=$(echo "$VAR" | sed -r 's/(LOG4J_[^=]*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
+        log4j_env=$(echo "$VAR" | sed -r 's/([^=]*)=.*/\1/g')
         if grep -E -q '(^|^#)'"$log4j_name=" "$KAFKA_HOME/config/log4j.properties"; then
             sed -r -i 's@(^|^#)('"$log4j_name"')=(.*)@\2='"${!log4j_env}"'@g' "$KAFKA_HOME/config/log4j.properties" #note that no config values may contain an '@' char
         else


### PR DESCRIPTION
Fix regex, otherwise script ends with:

> ... -Dcom.sun.management.jmxremote.rmi.port: bad substitution

Also unifying variable names.