### PR TITLE
Exclude broker KAFKA_xxx config when evaluating container KAFKA_xxx env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ script:
   - shellcheck -x -e SC1090 -s bash *sh
   - sleep 5 # Wait for containers to start
   - ./runAllTests.sh
+  # End-to-End scenario tests
+  - cd scenarios
+  - ./runJmxScenario.sh
 
 after_script:
   - docker-compose stop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+20-Apr-2018
+-----------
+
+-	Issue #312 - Fix conflict between KAFKA_xxx broker config values (e.g. KAFKA_JMX_OPTS) and container configuration options (e.g. KAFKA_CREATE_TOPICS)
+
 19-Apr-2018
 -----------
 

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -94,29 +94,45 @@ fi
 echo "" >> "$KAFKA_HOME/config/server.properties"
 
 (
+    function updateConfig() {
+        key=$1
+        value=$2
+        file=$3
+
+        # Omit $value here, in case there is sensitive information
+        echo "[Configuring] '$key' in '$file'"
+
+        # If config exists in file, replace it. Otherwise, append to file.
+        if grep -E -q "^#?$key=" "$file"; then
+            sed -r -i "s@^#?$key=.*@$key=$value@g" "$file" #note that no config values may contain an '@' char
+        else
+            echo "$key=$value" >> "$file"
+        fi
+    }
+
+    # Fixes #312
+    # KAFKA_VERSION + KAFKA_HOME + grep -rohe KAFKA[A-Z0-0_]* /opt/kafka/bin | sort | uniq | tr '\n' '|'
+    EXCLUSIONS="|KAFKA_VERSION|KAFKA_HOME|KAFKA_DEBUG|KAFKA_GC_LOG_OPTS|KAFKA_HEAP_OPTS|KAFKA_JMX_OPTS|KAFKA_JVM_PERFORMANCE_OPTS|KAFKA_LOG|KAFKA_OPTS|"
+
     # Read in env as a new-line separated array. This handles the case of env variables have spaces and/or carriage returns. See #313
     IFS=$'\n'
     for VAR in $(env)
     do
-      if [[ $VAR =~ ^KAFKA_ && ! $VAR =~ ^KAFKA_HOME ]]; then
-        kafka_name=$(echo "$VAR" | sed -r 's/KAFKA_([^=]*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-        kafka_env=$(echo "$VAR" | sed -r 's/([^=]*)=.*/\1/g')
-        if grep -E -q '(^|^#)'"$kafka_name=" "$KAFKA_HOME/config/server.properties"; then
-            sed -r -i 's@(^|^#)('"$kafka_name"')=(.*)@\2='"${!kafka_env}"'@g' "$KAFKA_HOME/config/server.properties" #note that no config values may contain an '@' char
-        else
-            echo "$kafka_name=${!kafka_env}" >> "$KAFKA_HOME/config/server.properties"
+        env_var=$(echo "$VAR" | cut -d= -f1)
+        if [[ "$EXCLUSIONS" = *"|$env_var|"* ]]; then
+            echo "Excluding $env_var from broker config"
+            continue
         fi
-      fi
 
-      if [[ $VAR =~ ^LOG4J_ ]]; then
-        log4j_name=$(echo "$VAR" | sed -r 's/(LOG4J_[^=]*)=.*/\1/g' | tr '[:upper:]' '[:lower:]' | tr _ .)
-        log4j_env=$(echo "$VAR" | sed -r 's/([^=]*)=.*/\1/g')
-        if grep -E -q '(^|^#)'"$log4j_name=" "$KAFKA_HOME/config/log4j.properties"; then
-            sed -r -i 's@(^|^#)('"$log4j_name"')=(.*)@\2='"${!log4j_env}"'@g' "$KAFKA_HOME/config/log4j.properties" #note that no config values may contain an '@' char
-        else
-            echo "$log4j_name=${!log4j_env}" >> "$KAFKA_HOME/config/log4j.properties"
+        if [[ $env_var =~ ^KAFKA_ ]]; then
+            kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ .)
+            updateConfig "$kafka_name" "${!env_var}" "$KAFKA_HOME/config/server.properties"
         fi
-      fi
+
+        if [[ $env_var =~ ^LOG4J_ ]]; then
+            log4j_name=$(echo "$env_var" | tr '[:upper:]' '[:lower:]' | tr _ .)
+            updateConfig "$log4j_name" "${!env_var}" "$KAFKA_HOME/config/log4j.properties"
+        fi
     done
 )
 

--- a/test/scenarios/Readme.md
+++ b/test/scenarios/Readme.md
@@ -1,0 +1,27 @@
+Scenarios (end-to-end tests)
+============================
+
+These tests are supposed to test the configuration of indivdiual features
+
+TODO:
+-----
+
+-	SSL (Client + Broker)
+-	Security
+
+Done:
+-----
+
+-	JMX
+
+Executing tests
+---------------
+
+These tests should spin up required containers for full end-to-end testing and exercise required code paths, returing zero exit code for success and non-zero exit code for failure.
+
+### JMX
+
+```
+cd test/scenarios
+./runJmxScenario.sh
+```

--- a/test/scenarios/jmx/docker-compose.yml
+++ b/test/scenarios/jmx/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092"
+      - "1099"
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_JMX_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=kafka -Dcom.sun.management.jmxremote.rmi.port=1099"
+      JMX_PORT: 1099
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  jmxexporter:
+    image: sscaling/jmx-prometheus-exporter
+    ports:
+      - "5556:5556"
+    environment:
+      SERVICE_PORT: 5556
+    volumes:
+      - $PWD/jmxexporter.yml:/opt/jmx_exporter/config.yml
+
+  test:
+    image: wurstmeister/kafka
+    environment:
+      KAFKA_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - .:/scenario
+    working_dir: /scenario
+    entrypoint:
+      - /bin/bash
+      - -c
+    command:
+      - /scenario/test.sh
+

--- a/test/scenarios/jmx/jmxexporter.yml
+++ b/test/scenarios/jmx/jmxexporter.yml
@@ -1,0 +1,9 @@
+---
+startDelaySeconds: 3
+hostPort: kafka:1099
+username:
+password:
+
+whitelistObjectNames: ["kafka.server:type=BrokerTopicMetrics,*"]
+rules:
+  - pattern: ".*"

--- a/test/scenarios/jmx/test.sh
+++ b/test/scenarios/jmx/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+echo "Sleeping 5 seconds until Kafka is started"
+sleep 5
+
+echo "Checking to see if Kafka is alive"
+echo "dump" | nc -w 20 zookeeper 2181 | fgrep "/brokers/ids/"
+
+echo "Check JMX"
+curl -s jmxexporter:5556/metrics | grep 'kafka_server_BrokerTopicMetrics_MeanRate{name="MessagesInPerSec",'

--- a/test/scenarios/runJmxScenario.sh
+++ b/test/scenarios/runJmxScenario.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+pushd jmx
+docker-compose up -d zookeeper kafka jmxexporter
+docker-compose run --rm test
+docker-compose stop
+popd

--- a/test/test.functions
+++ b/test/test.functions
@@ -5,6 +5,7 @@
 
 export START_KAFKA=/usr/bin/start-kafka.sh
 export BROKER_CONFIG=/opt/kafka/config/server.properties
+export ORIG_LOG4J_CONFIG=/opt/kafka/config/log4j.properties
 
 enforceOriginalFile() {
 	SOURCE="$1"
@@ -24,6 +25,7 @@ setupStartKafkaScript() {
 
 	enforceOriginalFile "$START_KAFKA"
 	enforceOriginalFile "$BROKER_CONFIG"
+	enforceOriginalFile "$ORIG_LOG4J_CONFIG"
 
 	# We need to remove all executable commands from the start-kafka.sh script, so it can be sourced to evaluate
 	# the environment variables
@@ -43,11 +45,22 @@ setupStartKafkaScript
 assertExpectedConfig() {
 	EXPECTED=$1
 
+	COUNT=$(grep -E '^'"$EXPECTED"'$' "$BROKER_CONFIG" | wc -l)
 	RESULT=$(grep -E '^'"$EXPECTED"'$' "$BROKER_CONFIG")
+	echo " > $COUNT matches of $RESULT"
+
+	[[ "$RESULT" == "$EXPECTED" && "$COUNT" == "1" ]]
+}
+
+assertExpectedLog4jConfig() {
+	EXPECTED=$1
+
+	RESULT=$(grep -E '^'"$EXPECTED"'$' "$ORIG_LOG4J_CONFIG")
 	echo " > $RESULT"
 
 	[[ "$RESULT" == "$EXPECTED" ]]
 }
+
 
 assertAbsent() {
 	EXPECTED_ABSENT=$1

--- a/test/test.start-kafka-bug-312-kafka-env.kafka.sh
+++ b/test/test.start-kafka-bug-312-kafka-env.kafka.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+source test.functions
+
+testKafkaEnv() {
+    # Given required settings are provided
+    export KAFKA_ADVERTISED_LISTENERS="PLAINTEXT://:9092"
+    export KAFKA_LISTENERS="PLAINTEXT://:9092"
+    export KAFKA_OPTS="-Djava.security.auth.login.config=/kafka_server_jaas.conf"
+
+    # When the script is invoked
+    source "$START_KAFKA"
+
+    # Then env should remain untouched
+    if [[ ! "$KAFKA_OPTS" == "-Djava.security.auth.login.config=/kafka_server_jaas.conf" ]]; then
+        echo "KAFKA_OPTS not set to expected value. $KAFKA_OPTS"
+        exit 1
+    fi
+
+    # And the broker config should not be set
+    assertAbsent 'opts'
+
+    echo " > Set KAFKA_OPTS=$KAFKA_OPTS"
+}
+
+testKafkaEnv

--- a/test/test.start-kafka-log4j-config.kafka.sh
+++ b/test/test.start-kafka-log4j-config.kafka.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+source test.functions
+
+testLog4jConfig() {
+	# Given Log4j overrides are provided
+	export KAFKA_LISTENERS=PLAINTEXT://:9092
+	export KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+
+	export LOG4J_LOGGER_KAFKA=DEBUG
+
+	# When the script is invoked
+	source "$START_KAFKA"
+
+	# Then the configuration file is correct
+	assertExpectedLog4jConfig "log4j.logger.kafka=DEBUG"
+}
+
+testLog4jConfig

--- a/test/test.start-kafka-restart.kafka.sh
+++ b/test/test.start-kafka-restart.kafka.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+source test.functions
+
+testRestart() {
+	# Given a hostname is provided
+	export KAFKA_LISTENERS="PLAINTEXT://:9092"
+
+	# When the container is restarted (Script invoked multiple times)
+	source "$START_KAFKA"
+	source "$START_KAFKA"
+
+	# Then the configuration file only has one instance of the config
+	assertExpectedConfig 'listeners=PLAINTEXT://:9092'
+}
+
+testRestart


### PR DESCRIPTION
values

* re-factor start-kafka.sh to reduce complexity of seds/regex etc
* Add scenario test for JMX (to validate this)
* Add test for restarting container
* Enhance start-kafka tests by asserting must only hvae one instance of
each expected config
* Add log4j config test