### PR TITLE
Provide override mechanism for versions pre-bootstrap

### DIFF
--- a/overrides/0.9.0.1.sh
+++ b/overrides/0.9.0.1.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# Kafka 0.9.x.x has a 'listeners' config by default. We need to remove this
+# as the user may be configuring via the host.name / advertised.host.name properties
+echo "Removing 'listeners' from server.properties pre-bootstrap"
+sed -i -e '/^listeners=/d' "$KAFKA_HOME/config/server.properties"

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -e
 
+# Allow specific kafka versions to perform any unique bootstrap operations
+OVERRIDE_FILE="/opt/overrides/${KAFKA_VERSION}.sh"
+if [[ -x "$OVERRIDE_FILE" ]]; then
+    echo "Executing override file $OVERRIDE_FILE"
+    eval "$OVERRIDE_FILE"
+fi
+
 # Store original IFS config, so we can restore it at various stages
 ORIG_IFS=$IFS
 


### PR DESCRIPTION
* Remove listeners for 0.9.0.1 kafka config, so bootstrap process can be the same