### PR TITLE
Generic handling of _COMMAND substitutions

### DIFF
--- a/docker-compose-scale.yaml
+++ b/docker-compose-scale.yaml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    build: .
+    ports:
+      - "9094"
+    environment:
+      INSIDE_HOSTNAME_COMMAND: "docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' `hostname`"
+      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://_{INSIDE_HOSTNAME_COMMAND}:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
I found a need for another `_COMMAND` substitution (other than `HOSTNAME_COMMAND` and `PORT_COMMAND`) so this PR modifies `start-kafka.sh` to handle any environment variable ending with `_COMMAND` generically and replace the placeholder with the command value after evaluation.

My use case was to have a kafka cluster working with scale `>1` and without hardcoded port forwarding and using the new `LISTENERS` kafka configuration.

The command substitution needed for such scenario is:

* `HOSTNAME_COMMAND` (already supported) for outside hostname in `KAFKA_ADVERTISED_LISTENERS`
* `PORT_COMMAND` (already supported) for outside port in `KAFKA_ADVERTISED_LISTENERS`
* `INSIDE_HOSTNAME_COMMAND` for inside hostname in `KAFKA_ADVERTISED_LISTENERS` which evaluates to the IP assigned to the docker container.

This PR also adds a docker-compose file (`docker-compose-scale.yaml`) which can be used for such scenario.