### PR TITLE
Fix Invalid interpolation and KAFKA_CREATE_TOPICS_SEPARATOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here is an example snippet from ```docker-compose.yml```:
 
 If you wish to use multi-line YAML or some other delimiter between your topic definitions, override the default `,` separator by specifying the `KAFKA_CREATE_TOPICS_SEPARATOR` environment variable.
 
-For example, `KAFKA_CREATE_TOPICS_SEPARATOR: "$$'\n"'` would use a newline to split the topic definitions. Syntax has to follow docker-compose escaping rules, and [ANSI-C](https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html) quoting.
+For example, `KAFKA_CREATE_TOPICS_SEPARATOR: "$$'\n'"` would use a newline to split the topic definitions. Syntax has to follow docker-compose escaping rules, and [ANSI-C](https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html) quoting.
 
 ## Advertised hostname
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The default ```docker-compose.yml``` should be seen as a starting point. By defa
 You can configure the broker id in different ways
 
 1. explicitly, using ```KAFKA_BROKER_ID```
-2. via a command, using ```BROKER_ID_COMMAND```, e.g. ```BROKER_ID_COMMAND: "hostname | awk -F'-' '{print $2}'"```
+2. via a command, using ```BROKER_ID_COMMAND```, e.g. ```BROKER_ID_COMMAND: "hostname | awk -F'-' '{print $$2}'"```
 
 If you don't specify a broker id in your docker-compose file, it will automatically be generated (see [https://issues.apache.org/jira/browse/KAFKA-1070](https://issues.apache.org/jira/browse/KAFKA-1070). This allows scaling up and down. In this case it is recommended to use the ```--no-recreate``` option of docker-compose to ensure that containers are not re-created and thus keep their names and ids.
 


### PR DESCRIPTION
```
ERROR: Invalid interpolation format for "environment" option in service "kafka": "hostname | awk -F'-' '{print $2}'"
```