### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Start a cluster:
 
 Add more brokers:
 
-- ```docker-compose scale kafka=3```
+- ```docker-compose up -d --scale kafka=3```
 
 Destroy a cluster:
 


### PR DESCRIPTION
Update instructions to scale the kafka brokers since the `scale` command of `docker-compose` is deprecated.

See https://docs.docker.com/compose/reference/scale/.

Fix #345