### PR TITLE
Add changing image to Pre-Requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Everytime the image is updated, all tags will be pushed with the latest updates.
 
 - install docker-compose [https://docs.docker.com/compose/install/](https://docs.docker.com/compose/install/)
 - modify the ```KAFKA_ADVERTISED_HOST_NAME``` in [docker-compose.yml](https://raw.githubusercontent.com/wurstmeister/kafka-docker/master/docker-compose.yml) to match your docker host IP (Note: Do not use localhost or 127.0.0.1 as the host ip if you want to run multiple brokers.)
+- replace the instruction ```build: .``` in [docker-compose.yml](https://raw.githubusercontent.com/wurstmeister/kafka-docker/master/docker-compose.yml) with ```image: wurstmeister/kafka``` (make sure that the indentation level stays the same)
 - if you want to customize any Kafka parameters, simply add them as environment variables in ```docker-compose.yml```, e.g. in order to increase the ```message.max.bytes``` parameter set the environment to ```KAFKA_MESSAGE_MAX_BYTES: 2000000```. To turn off automatic topic creation set ```KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'```
 - Kafka's log4j usage can be customized by adding environment variables prefixed with ```LOG4J_```. These will be mapped to ```log4j.properties```. For example: ```LOG4J_LOGGER_KAFKA_AUTHORIZER_LOGGER=DEBUG, authorizerAppender```
 


### PR DESCRIPTION
It is impossible to start the cluster locally as the docker-compose file from the documentation contains instruction to build the Kafka image instead of using the one from docker hub.

I updated the readme to include one more step to Pre-Requisites. 