### PR TITLE
Register the broker with its IP address

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -12,7 +12,7 @@ services:
         protocol: tcp
         mode: host
     environment:
-      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      HOSTNAME_COMMAND: "docker info -f '{{`{{.Swarm.NodeAddr}}`}}'"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
       KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:9094


### PR DESCRIPTION
We had an issue where our server running docker has hostname "server123" and the FQDN would be "server123.mycompany.com"

When a Kafka client (Java application) running in another container on the same docker host was connecting with the Kafka cluster it was configured to connect to the Kafka cluster using the FQDN. It connected ok, received from Kafka the address of the specific Kafka node to connect to: "server123" which contained no longer the FQDN. This caused the connection to fail as the Kafka client could not resolve a non-FQDN hostname "server123". 

Altering the HOSTNAME_COMMAND of the Kafka node to return the IP adress instead of the non-FQDN hostname solved the issue for us. 