### PR TITLE
Make provisions for passing passwords into the container with Docker secret

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -129,6 +129,13 @@ echo "" >> "$KAFKA_HOME/config/server.properties"
             echo "Excluding $env_var from broker config"
             continue
         fi
+        #add the file extension
+	if [[ $env_var == KAFKA_*_FILE ]]; then
+            #kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ .)
+	    kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ . | rev | cut -c6- | rev)
+	    echo $kafka_name=$(cat $env_var) >> $KAFKA_HOME/config/server.properties
+            #updateConfig "$kafka_name" "${!env_var}" "$KAFKA_HOME/config/server.properties"
+        fi
 
         if [[ $env_var =~ ^KAFKA_ ]]; then
             kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ .)

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -129,12 +129,11 @@ echo "" >> "$KAFKA_HOME/config/server.properties"
             echo "Excluding $env_var from broker config"
             continue
         fi
-        #add the file extension
-	if [[ $env_var == KAFKA_*_FILE ]]; then
-            #kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ .)
+        
+	#if the environment variable contains the word "FILE" remove the file part of the environment variable and copy the content of the file into the server.properties file
+	if [[ $env_var == *_FILE* ]]; then
 	    kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ . | rev | cut -c6- | rev)
 	    echo $kafka_name=$(cat ${!env_var}) >> $KAFKA_HOME/config/server.properties
-            #updateConfig "$kafka_name" "${!env_var}" "$KAFKA_HOME/config/server.properties"
         fi
 
         if [[ $env_var =~ ^KAFKA_ ]]; then

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -133,7 +133,7 @@ echo "" >> "$KAFKA_HOME/config/server.properties"
 	if [[ $env_var == KAFKA_*_FILE ]]; then
             #kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ .)
 	    kafka_name=$(echo "$env_var" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]' | tr _ . | rev | cut -c6- | rev)
-	    echo $kafka_name=$(cat $env_var) >> $KAFKA_HOME/config/server.properties
+	    echo $kafka_name=$(cat ${!env_var}) >> $KAFKA_HOME/config/server.properties
             #updateConfig "$kafka_name" "${!env_var}" "$KAFKA_HOME/config/server.properties"
         fi
 


### PR DESCRIPTION
I'm sure there's a better way to do this but I added an extra if statement to cater for passing environment variables like KAFKA_SSL_KEYSTORE_PASSWORD as KAFKA_SSL_KEYSTORE_PASSWORD_FILE instead.

The if statement then copies the content of the file into the $KAFKA_HOME/config/server.properties file.

For example;
environment:
     KAFKA_SSL_KEYSTORE_PASSWORD: 'secret'

becomes 

environment:
     KAFKA_SSL_KEYSTORE_PASSWORD_FILE: '/run/secrets/kafka_keystore_pswd'
secrets:
   - kafka_keystore_pswd

Then the content of the /run/secrets/kafka_keystore_pswd gets copied into the server.properties file.

I noticed however that an extra property (ssl.keystore.password.file in this case) also gets copied into the server.properties file which isn't really needed but works fine anyway.
