### PR TITLE
Kafka 2.1.1, glibc 2.29-r0, openjdk:8u201-jre-alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 # This version will be also tagged as 'latest'
 env:
   global:
-    - LATEST="2.12-2.1.0"
+    - LATEST="2.12-2.1.1"
 
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
@@ -28,7 +28,7 @@ matrix:
   - scala: 2.12
     env: KAFKA_VERSION=2.0.1
   - scala: 2.12
-    env: KAFKA_VERSION=2.1.0
+    env: KAFKA_VERSION=2.1.1
 
 install:
   - docker --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,18 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+21-Feb-2019
+-----------
+
+-	Update to latest Kafka: `2.1.1`
+-	Update glibc to `2.29-r0`
+-	Update base image to openjdk:8u201-jre-alpine
+
 21-Nov-2018
 -----------
 
-- Update to latest Kafka: `2.1.0`
-- Set scala version for Kafka `2.1.0` and `2.0.1` to recommended `2.12`
+-	Update to latest Kafka: `2.1.0`
+-	Set scala version for Kafka `2.1.0` and `2.0.1` to recommended `2.12`
 
 10-Nov-2018
 -----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8u191-jre-alpine
+FROM openjdk:8u201-jre-alpine
 
-ARG kafka_version=2.1.0
+ARG kafka_version=2.1.1
 ARG scala_version=2.12
-ARG glibc_version=2.28-r0
+ARG glibc_version=2.29-r0
 ARG vcs_ref=unspecified
 ARG build_date=unspecified
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tags and releases
 
 All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
 
-- `2.12-2.1.0`
+- `2.12-2.1.1`
 - `2.12-2.0.1`
 - `2.11-1.1.1`
 - `2.11-1.0.2`

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
-       - KAFKA_VERSION=${KAFKA_VERSION-2.1.0}
+       - KAFKA_VERSION=${KAFKA_VERSION-2.1.1}
     volumes:
       - .:/tests
     working_dir: /tests


### PR DESCRIPTION
Updated versions:

* Kafka: 2.1.1
* glibc 2.29-r0
* openjdk:8u201-jre-alpine