### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ KAFKA_ADVERTISED_LISTENERS=SSL://_{HOSTNAME_COMMAND}:9093,PLAINTEXT://9092
 If the required advertised port is not static, it may be necessary to determine this programatically. This can be done with the `PORT_COMMAND` environment variable.
 
 ```
-PORT_COMMAND: "docker port $$(hostname) 9092/tcp | cut -d: -f2
+PORT_COMMAND: "docker port $$(hostname) 9092/tcp | cut -d: -f2"
 ```
 
 This can be then interpolated in any other `KAFKA_XXX` config using the `_{PORT_COMMAND}` string, i.e.


### PR DESCRIPTION
Missing and ending doublequote character `HOSTNAME_COMMAND` injection.