### PR TITLE
Restart Kafka when restarting Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: wurstmeister/zookeeper
     ports:
       - "2181:2181"
+    restart: unless-stopped
+
   kafka:
     build: .
     ports:
@@ -13,3 +15,4 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped


### PR DESCRIPTION
With this you will not need to remember to run `docker-compose -up` after restarting **Docker** or the whole machine.