### PR TITLE
Add Docker image tag to avoid redownload id

### DIFF
--- a/docker-compose-single-broker.yml
+++ b/docker-compose-single-broker.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafka:
+    image: wurstmeister/kafka
     build: .
     ports:
       - "9092:9092"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - "2181:2181"
   kafka:
+    image: wurstmeister/kafka
     build: .
     ports:
       - "9092"


### PR DESCRIPTION
The `docker-compose.yml` and `docker-compose-single-broker.yml` file did not contain a tag for the generated image.

So, when running `start-kafka-shell.sh`, the image `wurstmeister/kafka` is not found, which forces to download the image from Docker Hub.