### PR TITLE
Add a case sensitive option for adding entries to log4j.properties

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -139,6 +139,11 @@ echo "" >> "$KAFKA_HOME/config/server.properties"
             log4j_name=$(echo "$env_var" | tr '[:upper:]' '[:lower:]' | tr _ .)
             updateConfig "$log4j_name" "${!env_var}" "$KAFKA_HOME/config/log4j.properties"
         fi
+
+        if [[ $env_var =~ ^log4j_ ]]; then
+            log4j_name=$(echo "$env_var" | tr _ .)
+            updateConfig "$log4j_name" "${!env_var}" "$KAFKA_HOME/config/log4j.properties"
+        fi
     done
 )
 

--- a/test/0.0/test.start-kafka-log4j-config.kafka.sh
+++ b/test/0.0/test.start-kafka-log4j-config.kafka.sh
@@ -6,12 +6,14 @@ testLog4jConfig() {
 	# Given Log4j overrides are provided
 	export KAFKA_ADVERTISED_HOST_NAME="testhost"
 	export LOG4J_LOGGER_KAFKA=DEBUG
+	export log4j_logger_kafka_server_KafkaConfig=WARN
 
 	# When the script is invoked
 	source "$START_KAFKA"
 
 	# Then the configuration file is correct
 	assertExpectedLog4jConfig "log4j.logger.kafka=DEBUG"
+	assertExpectedLog4jConfig "log4j.logger.kafka.server.KafkaConfig=WARN"
 }
 
 testLog4jConfig


### PR DESCRIPTION
#188 / 5d324f14ccd7030355e618e81a31ef0d45dcba35 added reading the LOG4J_ environment variables, but converts all keys to lowercase.
Please correct me if I'm wrong on this: Matches in log4j.properties are case sensitive, this LOG4J_ only allowed configuring logging per package (since java package names are lower case), but not for single classes (which are in CamelCase).

I've decided to keep LOG4J_ for backwards compatibility. Also note that I think this PR is of minor importance, since the functionality of both log4j_ and LOG4J_ can be easily replaced by
```yaml
    entrypoint: |
      bash -c "
        echo >>/opt/kafka/config/log4j.properties log4j.logger.kafka.server.KafkaConfig=WARN
        exec start-kafka.sh
      "
```
and similar tricks.