### PR TITLE
Add support for Kafka 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 # This version will be also tagged as 'latest'
 env:
   global:
-    - LATEST="2.12-2.5.0"
+    - LATEST="2.13-2.6.0"
 
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
@@ -37,6 +37,8 @@ matrix:
     env: KAFKA_VERSION=2.4.1
   - scala: 2.12
     env: KAFKA_VERSION=2.5.0
+  - scala: 2.13
+    env: KAFKA_VERSION=2.6.0
 
 install:
   - docker --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+06-Aug-2020
+-----------
+
+-	Add support for Kafka `2.6.0`
+
 20-Apr-2020
 -----------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u212-jre-alpine
 
-ARG kafka_version=2.5.0
-ARG scala_version=2.12
+ARG kafka_version=2.6.0
+ARG scala_version=2.13
 ARG glibc_version=2.31-r0
 ARG vcs_ref=unspecified
 ARG build_date=unspecified

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tags and releases
 
 All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
 
+- `2.13-2.6.0`
 - `2.12-2.5.0`
 - `2.12-2.4.1`
 - `2.12-2.3.1`

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
-       - KAFKA_VERSION=${KAFKA_VERSION-2.5.0}
+       - KAFKA_VERSION=${KAFKA_VERSION-2.6.0}
     volumes:
       - .:/tests
     working_dir: /tests


### PR DESCRIPTION
Kafka 2.6.0 was announced today 2020-08-06 on Apache's blog
https://blogs.apache.org/kafka/entry/what-s-new-in-apache3.

This PR adds support for it using the previous `2.5.0` upgrade as a template
https://github.com/wurstmeister/kafka-docker/pull/589

The scala version was upgraded from `2.12` to `2.13` as recommended on the
download page https://kafka.apache.org/downloads.html