### PR TITLE
Add support for Kafka 2.5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ matrix:
   - scala: 2.12
     env: KAFKA_VERSION=2.4.1
   - scala: 2.12
-    env: KAFKA_VERSION=2.5.0
-  - scala: 2.12
     env: KAFKA_VERSION=2.5.1
   - scala: 2.13
     env: KAFKA_VERSION=2.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 # This version will be also tagged as 'latest'
 env:
   global:
-    - LATEST="2.13-2.7.0"
+    - LATEST="2.13-2.7.1"
 
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
@@ -28,7 +28,7 @@ matrix:
   - scala: 2.13
     env: KAFKA_VERSION=2.6.0
   - scala: 2.13
-    env: KAFKA_VERSION=2.7.0
+    env: KAFKA_VERSION=2.7.1
 
 install:
   - docker --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
     env: KAFKA_VERSION=2.4.1
   - scala: 2.12
     env: KAFKA_VERSION=2.5.0
+  - scala: 2.12
+    env: KAFKA_VERSION=2.5.1
   - scala: 2.13
     env: KAFKA_VERSION=2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+20-Jul-2021
+-----------
+
+-	Add support for Kafka `2.7.1`
+
 06-Jun-2021
 ----------
 - Add support for darwin arm by to azul/zulu-openjdk-alpine base image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+09-Oct-2020
+-----------
+
+-	Add support for Kafka `2.5.1`
+
 06-Aug-2020
 -----------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM azul/zulu-openjdk-alpine:8u292-8.54.0.21
 
-ARG kafka_version=2.7.0
+ARG kafka_version=2.7.1
 ARG scala_version=2.13
 ARG glibc_version=2.31-r0
 ARG vcs_ref=unspecified

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tags and releases
 All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
 
 - `2.13-2.6.0`
+- `2.12-2.5.1`
 - `2.12-2.5.0`
 - `2.12-2.4.1`
 - `2.12-2.3.1`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ All versions of the image are built from the same set of scripts with only minor
 
 - `2.13-2.6.0`
 - `2.12-2.5.1`
-- `2.12-2.5.0`
 - `2.12-2.4.1`
 - `2.12-2.3.1`
 - `2.12-2.2.2`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tags and releases
 
 All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
 
-- `2.13-2.7.0`
+- `2.13-2.7.1`
 - `2.13-2.6.0`
 - `2.12-2.5.1`
 - `2.12-2.4.1`

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
-       - KAFKA_VERSION=${KAFKA_VERSION-2.7.0}
+       - KAFKA_VERSION=${KAFKA_VERSION-2.7.1}
     volumes:
       - .:/tests
     working_dir: /tests


### PR DESCRIPTION
AWS MSK recently added support for Kafka 2.5.1.  It would be useful to have a matching version of this kafka-docker image for local Docker based testing.