### PR TITLE
Allow global topic configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,14 @@ Here is an example snippet from ```docker-compose.yml```:
 
 ```Topic 1``` will have 1 partition and 3 replicas, ```Topic 2``` will have 1 partition, 1 replica and a `cleanup.policy` set to `compact`. Also, see FAQ: [Topic compaction does not work](https://github.com/wurstmeister/kafka-docker/wiki#topic-compaction-does-not-work)
 
-If you wish to use multi-line YAML or some other delimiter between your topic definitions, override the default `,` separator by specifying the `KAFKA_CREATE_TOPICS_SEPARATOR` environment variable.
+If you'd like to add default configurations to all topics, for instance removing the retention, you can do it via:
+
+        environment:
+          KAFKA_CREATE_TOPICS_DEFAULT_CONFIG: "retention.ms=-1,retention.bytes=-1"
+
+Check all available [Kafka topic configs](https://kafka.apache.org/documentation/#topicconfigs)
+
+If you wish to use multi-line YAML or some other delimiter between your topic definitions and configs, override the default `,` separator by specifying the `KAFKA_CREATE_TOPICS_SEPARATOR` environment variable.
 
 For example, `KAFKA_CREATE_TOPICS_SEPARATOR: "$$'\n'"` would use a newline to split the topic definitions. Syntax has to follow docker-compose escaping rules, and [ANSI-C](https://www.gnu.org/software/bash/manual/html_node/ANSI_002dC-Quoting.html) quoting.
 

--- a/create-topics.sh
+++ b/create-topics.sh
@@ -34,9 +34,17 @@ if [[ "$MAJOR_VERSION" == "0" && "$MINOR_VERSION" -gt "9" ]] || [[ "$MAJOR_VERSI
 fi
 
 # Expected format:
+#   config=value,
+# Available configs: https://kafka.apache.org/documentation/#topicconfigs
+topicConfigDefault=
+IFS="${KAFKA_CREATE_TOPICS_SEPARATOR-,}"; for config in $KAFKA_CREATE_TOPICS_DEFAULT_CONFIG; do
+    topicConfigDefault="${topicConfigDefault} --config=${config//[[:space:]]/}"
+done
+
+# Expected format:
 #   name:partitions:replicas:cleanup.policy
 IFS="${KAFKA_CREATE_TOPICS_SEPARATOR-,}"; for topicToCreate in $KAFKA_CREATE_TOPICS; do
-    echo "creating topics: $topicToCreate"
+    echo "creating topics: $topicToCreate with default config \"$topicConfigDefault\""
     IFS=':' read -r -a topicConfig <<< "$topicToCreate"
     config=
     if [ -n "${topicConfig[3]}" ]; then
@@ -49,6 +57,7 @@ IFS="${KAFKA_CREATE_TOPICS_SEPARATOR-,}"; for topicToCreate in $KAFKA_CREATE_TOP
 		--topic ${topicConfig[0]} \\
 		--partitions ${topicConfig[1]} \\
 		--replication-factor ${topicConfig[2]} \\
+		${topicConfigDefault} \\
 		${config} \\
 		${KAFKA_0_10_OPTS} &"
     eval "${COMMAND}"


### PR DESCRIPTION
This feature enables users to add multiple common configs to all topics being created by the initial script.

The change should be backward compatible and follow the current standards.
