### PR TITLE
Dynamic Listener configuration for Kubernetes deployment  and fixing java core dumping for AMR64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-alpine
+FROM openjdk:8u201-jre-alpine
 
 ARG kafka_version=2.7.0
 ARG scala_version=2.13

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -80,6 +80,13 @@ if [[ -n "$RACK_COMMAND" && -z "$KAFKA_BROKER_RACK" ]]; then
     export KAFKA_BROKER_RACK
 fi
 
+# Eval listeners command
+if [[ -n "$KAFKA_LISTENERS_COMMAND" ]]; then
+    KAFKA_LISTENERS=$(eval "$KAFKA_LISTENERS_COMMAND")
+    export KAFKA_LISTENERS
+    unset KAFKA_LISTENERS_COMMAND
+fi
+
 # Try and configure minimal settings or exit with error if there isn't enough information
 if [[ -z "$KAFKA_ADVERTISED_HOST_NAME$KAFKA_LISTENERS" ]]; then
     if [[ -n "$KAFKA_ADVERTISED_LISTENERS" ]]; then


### PR DESCRIPTION
* For ARM64 arch, switching base image from 'openjdk:8u212-jre-alpine' to 'openjdk:8u201-jre-alpine' to prevent container core dump [@see issue](https://github.com/openhab/openhab-docker/issues/233).
* For K8S deployment, add a 'KAFKA_LISTENERS_COMMAND' environment parameter to build 'KAFKA_LISTENERS' on fly (to use pod hostname when container started) [@see start_kafka.sh](kafka/docker/start_kafka.sh)
```docker
if [[ -n "$KAFKA_LISTENERS_COMMAND" ]]; then
    KAFKA_LISTENERS=$(eval "$KAFKA_LISTENERS_COMMAND")
    export KAFKA_LISTENERS
    unset KAFKA_LISTENERS_COMMAND
fi
```