### PR TITLE
Add support for Kafka version 2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,6 @@ env:
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
   include:
-  - scala: "2.10"
-    env: KAFKA_VERSION=0.8.2.2
-  - scala: 2.11
-    env: KAFKA_VERSION=0.9.0.1
-  - scala: 2.11
-    env: KAFKA_VERSION=0.10.2.2
-  - scala: 2.11
-    env: KAFKA_VERSION=0.11.0.3
-  - scala: 2.11
-    env: KAFKA_VERSION=1.0.2
-  - scala: 2.11
-    env: KAFKA_VERSION=1.1.1
   - scala: 2.12
     env: KAFKA_VERSION=2.0.1
   - scala: 2.12
@@ -48,6 +36,7 @@ install:
   - echo "KAFKA VERSION  $KAFKA_VERSION"
   - echo "SCALA VERSION  $TRAVIS_SCALA_VERSION"
   - echo "LATEST VERSION $LATEST"
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - export CURRENT=${TRAVIS_SCALA_VERSION}-${KAFKA_VERSION}
   - docker build --build-arg kafka_version=$KAFKA_VERSION --build-arg scala_version=$TRAVIS_SCALA_VERSION --build-arg vcs_ref=$TRAVIS_COMMIT --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") -t wurstmeister/kafka .
   - docker pull confluentinc/cp-kafkacat

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   - echo "KAFKA VERSION  $KAFKA_VERSION"
   - echo "SCALA VERSION  $TRAVIS_SCALA_VERSION"
   - echo "LATEST VERSION $LATEST"
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - if [ -z ${DOCKER_PASSWORD+x} ]; then echo "Using unauthenticated pulls on PR"; else echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; fi
   - export CURRENT=${TRAVIS_SCALA_VERSION}-${KAFKA_VERSION}
   - docker build --build-arg kafka_version=$KAFKA_VERSION --build-arg scala_version=$TRAVIS_SCALA_VERSION --build-arg vcs_ref=$TRAVIS_COMMIT --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") -t wurstmeister/kafka .
   - docker pull confluentinc/cp-kafkacat

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 services:
   - docker
 
-# This version will be also tagged as 'latest'
+# This release is experimental only, previous version is remains 'latest'
 env:
   global:
     - LATEST="2.13-2.7.0"
@@ -29,6 +29,8 @@ matrix:
     env: KAFKA_VERSION=2.6.0
   - scala: 2.13
     env: KAFKA_VERSION=2.7.0
+  - scala: 2.13
+    env: KAFKA_VERSION=2.8.0
 
 install:
   - docker --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ language: scala
 services:
   - docker
 
-# This release is experimental only, previous version is remains 'latest'
+# This version will be also tagged as 'latest'
 env:
   global:
-    - LATEST="2.13-2.7.0"
+    - LATEST="2.13-2.8.0"
 
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+06-Jun-2021
+----------
+- Add support for darwin arm by to azul/zulu-openjdk-alpine base image
+
 05-Jun-2021
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+05-Jun-2021
+-----------
+
+- Dropped support for versions < 2.0.1
+
 30-Dec-2020
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Kafka features are not tied to a specific kafka-docker version (ideally all chan
 
 - Dropped support for versions < 2.0.1
 
+20-Apr-2021
+-----------
+
+-	Add support for experimental Kafka `2.8.0`
+
 30-Dec-2020
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+08-Jul-2021
+-----------
+-	Add support for experimental Kafka `2.8.0`
+
 06-Jun-2021
 ----------
 - Add support for darwin arm by to azul/zulu-openjdk-alpine base image
@@ -11,11 +15,6 @@ Kafka features are not tied to a specific kafka-docker version (ideally all chan
 -----------
 
 - Dropped support for versions < 2.0.1
-
-20-Apr-2021
------------
-
--	Add support for experimental Kafka `2.8.0`
 
 30-Dec-2020
 -----------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-alpine
+FROM azul/zulu-openjdk-alpine:8u292-8.54.0.21
 
 ARG kafka_version=2.7.0
 ARG scala_version=2.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM azul/zulu-openjdk-alpine:8u292-8.54.0.21
 
-ARG kafka_version=2.7.0
+ARG kafka_version=2.8.0
 ARG scala_version=2.13
 ARG glibc_version=2.31-r0
 ARG vcs_ref=unspecified

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tags and releases
 
 All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
 
+- `2.13-2.8.0`
 - `2.13-2.7.0`
 - `2.13-2.6.0`
 - `2.12-2.5.0`

--- a/broker-list.sh
+++ b/broker-list.sh
@@ -2,4 +2,4 @@
 
 CONTAINERS=$(docker ps | grep 9092 | awk '{print $1}')
 BROKERS=$(for CONTAINER in ${CONTAINERS}; do docker port "$CONTAINER" 9092 | sed -e "s/0.0.0.0:/$HOST_IP:/g"; done)
-echo "${BROKERS/$'\n'/,}"
+echo "${BROKERS//$'\n'/,}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "9092"
     environment:
+      DOCKER_API_VERSION: 1.22
       KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -9,7 +9,7 @@ url=$(curl --stderr /dev/null "https://www.apache.org/dyn/closer.cgi?path=/kafka
 
 # Test to see if the suggested mirror has this version, currently pre 2.1.1 versions
 # do not appear to be actively mirrored. This may also be useful if closer.cgi is down.
-if [[ ! $(curl -s -f -I "${url}") ]]; then
+if [[ ! $(curl -f -s -r 0-1 "${url}") ]]; then
     echo "Mirror does not have desired version, downloading direct from Apache"
     url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${FILENAME}"
 fi

--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -52,7 +52,7 @@ fi
 if [[ -n "$HOSTNAME_COMMAND" ]]; then
     HOSTNAME_VALUE=$(eval "$HOSTNAME_COMMAND")
 
-    # Replace any occurences of _{HOSTNAME_COMMAND} with the value
+    # Replace any occurrences of _{HOSTNAME_COMMAND} with the value
     IFS=$'\n'
     for VAR in $(env); do
         if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{HOSTNAME_COMMAND}" ]]; then
@@ -65,7 +65,7 @@ fi
 if [[ -n "$PORT_COMMAND" ]]; then
     PORT_VALUE=$(eval "$PORT_COMMAND")
 
-    # Replace any occurences of _{PORT_COMMAND} with the value
+    # Replace any occurrences of _{PORT_COMMAND} with the value
     IFS=$'\n'
     for VAR in $(env); do
         if [[ $VAR =~ ^KAFKA_ && "$VAR" =~ "_{PORT_COMMAND}" ]]; then

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
-       - KAFKA_VERSION=${KAFKA_VERSION-2.7.0}
+       - KAFKA_VERSION=${KAFKA_VERSION-2.8.0}
     volumes:
       - .:/tests
     working_dir: /tests


### PR DESCRIPTION
- Kafka Version 2.8.0 has first release of  KIP 500 (Removes dependence on zookeeper)
- However, current release is for development only because zookeeper is still required for Access Control List in Kafka
- See Kafka latest release log