### PR TITLE
feat: jdk-11-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-alpine
+FROM docker.io/bellsoft/liberica-openjdk-alpine:11
 
 ARG kafka_version=2.7.0
 ARG scala_version=2.13
@@ -22,20 +22,27 @@ ENV KAFKA_VERSION=$kafka_version \
 
 ENV PATH=${PATH}:${KAFKA_HOME}/bin
 
-COPY download-kafka.sh start-kafka.sh broker-list.sh create-topics.sh versions.sh /tmp/
+RUN apk add --no-cache bash curl jq docker wget
 
-RUN apk add --no-cache bash curl jq docker \
- && chmod a+x /tmp/*.sh \
- && mv /tmp/start-kafka.sh /tmp/broker-list.sh /tmp/create-topics.sh /tmp/versions.sh /usr/bin \
- && sync && /tmp/download-kafka.sh \
- && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt \
- && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz \
- && ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} ${KAFKA_HOME} \
- && rm /tmp/* \
- && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
- && apk add --no-cache --allow-untrusted glibc-${GLIBC_VERSION}.apk \
- && rm glibc-${GLIBC_VERSION}.apk
+COPY download-kafka.sh /tmp/
+COPY versions.sh /usr/bin/
 
+RUN chmod a+x /tmp/*.sh && chmod a+x /usr/bin/*.sh
+
+RUN sync && /tmp/download-kafka.sh \
+    && tar xfz /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz -C /opt \
+    && rm /tmp/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz \
+    && ln -s /opt/kafka_${SCALA_VERSION}-${KAFKA_VERSION} ${KAFKA_HOME} \
+    && rm /tmp/*
+
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-bin-${GLIBC_VERSION}.apk \
+    && apk add --no-cache --allow-untrusted glibc-${GLIBC_VERSION}.apk glibc-bin-${GLIBC_VERSION}.apk \
+    && rm glibc-${GLIBC_VERSION}.apk  && rm glibc-bin-${GLIBC_VERSION}.apk
+
+RUN apk del wget curl jq
+
+COPY start-kafka.sh broker-list.sh create-topics.sh /usr/bin/
 COPY overrides /opt/overrides
 
 VOLUME ["/kafka"]

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 # shellcheck disable=SC1091
 source "/usr/bin/versions.sh"


### PR DESCRIPTION
Changed base image to bellsoft/liberica-openjdk-alpine:11
Added required package glibc-bin-${GLIBC_VERSION}.apk
Refactored build execution commands to optimize stages cache.
Removing ununsed packeges from image