### PR TITLE
Update openjdk image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+06-Jun-2021
+----------
+- Add support for darwin arm by to azul/zulu-openjdk-alpine base image
+
 05-Jun-2021
 -----------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u212-jre-alpine
+FROM azul/zulu-openjdk-alpine:8u292-8.54.0.21
 
 ARG kafka_version=2.7.0
 ARG scala_version=2.13

--- a/download-kafka.sh
+++ b/download-kafka.sh
@@ -9,7 +9,7 @@ url=$(curl --stderr /dev/null "https://www.apache.org/dyn/closer.cgi?path=/kafka
 
 # Test to see if the suggested mirror has this version, currently pre 2.1.1 versions
 # do not appear to be actively mirrored. This may also be useful if closer.cgi is down.
-if [[ ! $(curl -s -f -I "${url}") ]]; then
+if [[ ! $(curl -f -s -r 0-1 "${url}") ]]; then
     echo "Mirror does not have desired version, downloading direct from Apache"
     url="https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/${FILENAME}"
 fi


### PR DESCRIPTION
The previous image was crashing on M1. After trying a few different
images, this one seems to solve the problem

Closes https://github.com/wurstmeister/kafka-docker/issues/647