### PR TITLE
Fix sed: unmatched '@'

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -26,7 +26,7 @@ if [[ -z "$KAFKA_ADVERTISED_PORT" && \
   -z "$KAFKA_LISTENERS" && \
   -z "$KAFKA_ADVERTISED_LISTENERS" && \
   -S /var/run/docker.sock ]]; then
-    KAFKA_ADVERTISED_PORT=$(docker port "$(hostname)" $KAFKA_PORT | sed -r 's/.*:(.*)/\1/g')
+    KAFKA_ADVERTISED_PORT=$(docker port "$(hostname)" $KAFKA_PORT | sed -r 's/.*:(.*)/\1/g') | head -n1
     export KAFKA_ADVERTISED_PORT
 fi
 


### PR DESCRIPTION
When a container is restarted `docker port` reports multiple ports which yields the error `sed: unmatched '@'` because there's a newline in the sed result. This change picks the first port, which removes the first line.