### PR TITLE
Add support for Kafka 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 # This version will be also tagged as 'latest'
 env:
   global:
-    - LATEST="2.13-2.7.0"
+    - LATEST="2.13-2.7.1"
 
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
@@ -28,7 +28,7 @@ matrix:
   - scala: 2.13
     env: KAFKA_VERSION=2.6.0
   - scala: 2.13
-    env: KAFKA_VERSION=2.7.0
+    env: KAFKA_VERSION=2.7.1
 
 install:
   - docker --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+19-July-2021
+----------
+
+-	Add support for Kafka `2.7.1`
+
 06-Jun-2021
 ----------
 - Add support for darwin arm by to azul/zulu-openjdk-alpine base image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM azul/zulu-openjdk-alpine:8u292-8.54.0.21
 
-ARG kafka_version=2.7.0
+ARG kafka_version=2.7.1
 ARG scala_version=2.13
 ARG glibc_version=2.31-r0
 ARG vcs_ref=unspecified

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tags and releases
 
 All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
 
-- `2.13-2.7.0`
+- `2.13-2.7.1`
 - `2.13-2.6.0`
 - `2.12-2.5.0`
 - `2.12-2.4.1`

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
-       - KAFKA_VERSION=${KAFKA_VERSION-2.7.0}
+       - KAFKA_VERSION=${KAFKA_VERSION-2.7.1}
     volumes:
       - .:/tests
     working_dir: /tests


### PR DESCRIPTION
Kafka 2.7.1 fixes several bugs since the 2.7.0 release, and it is the latest version as of today for the 2.7.x.

https://downloads.apache.org/kafka/2.7.1/RELEASE_NOTES.html