### PR TITLE
Support multi-architecture builds for amd64 and arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,18 @@ env:
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
   include:
+  - scala: 2.10
+    env: KAFKA_VERSION=0.8.2.2
+  - scala: 2.11
+    env: KAFKA_VERSION=0.9.0.1
+  - scala: 2.11
+    env: KAFKA_VERSION=0.10.2.2
+  - scala: 2.11
+    env: KAFKA_VERSION=0.11.0.3
+  - scala: 2.11
+    env: KAFKA_VERSION=1.0.2
+  - scala: 2.11
+    env: KAFKA_VERSION=1.1.1
   - scala: 2.12
     env: KAFKA_VERSION=2.0.1
   - scala: 2.12
@@ -30,15 +42,33 @@ matrix:
   - scala: 2.13
     env: KAFKA_VERSION=2.7.1
 
+# Upgrade Docker Engine so we can use buildx
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
 install:
   - docker --version
+  - docker buildx version
   - docker-compose --version
   - echo "KAFKA VERSION  $KAFKA_VERSION"
   - echo "SCALA VERSION  $TRAVIS_SCALA_VERSION"
   - echo "LATEST VERSION $LATEST"
   - if [ -z ${DOCKER_PASSWORD+x} ]; then echo "Using unauthenticated pulls on PR"; else echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; fi
   - export CURRENT=${TRAVIS_SCALA_VERSION}-${KAFKA_VERSION}
-  - docker build --build-arg kafka_version=$KAFKA_VERSION --build-arg scala_version=$TRAVIS_SCALA_VERSION --build-arg vcs_ref=$TRAVIS_COMMIT --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") -t wurstmeister/kafka .
+
+  # Prepare the environment for multi-arch builds
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - docker buildx create --use
+
+  # Build all of the platforms and cache the result
+  - bash docker_buildx
+
+  # Using the multi-arch build cache, load the current architecture image into docker for the
+  # subsequent docker-compose/test stuff.
+  - bash docker_buildx --load
   - docker pull confluentinc/cp-kafkacat
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docker Stars](https://img.shields.io/docker/stars/wurstmeister/kafka.svg)](https://hub.docker.com/r/wurstmeister/kafka/)
 [![](https://images.microbadger.com/badges/version/wurstmeister/kafka.svg)](https://microbadger.com/images/wurstmeister/kafka "Get your own version badge on microbadger.com")
 [![](https://images.microbadger.com/badges/image/wurstmeister/kafka.svg)](https://microbadger.com/images/wurstmeister/kafka "Get your own image badge on microbadger.com")
-[![Build Status](https://app.travis-ci.com/wurstmeister/kafka-docker.svg?branch=master)](https://travis-ci.org/wurstmeister/kafka-docker)
+[![Build Status](https://app.travis-ci.com/wurstmeister/kafka-docker.svg?branch=master)](https://app.travis-ci.com/wurstmeister/kafka-docker)
 
 
 kafka-docker

--- a/docker_buildx
+++ b/docker_buildx
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+# Build for amd64 and arm64
+PLATFORMS="linux/amd64,linux/arm64"
+
+EXTRA_BUILDX_ARGS=$@
+CACHE_LOCATION="/tmp/docker-cache"
+
+if [[ "${EXTRA_BUILDX_ARGS}" == *"--load"* ]]; then
+    # We have to load the image for the current architecture only in order to run tests, so let's
+    # pull FROM the multi-arch build that happened previously
+    PLATFORMS="linux/${TRAVIS_CPU_ARCH}"
+    CACHE="--cache-from=type=local,src=${CACHE_LOCATION}"
+elif [[ "${EXTRA_BUILDX_ARGS}" == *"--push"* ]]; then
+    # Push ALL architectures FROM the multi-arch build cache that happened previously
+    CACHE="--cache-from=type=local,src=${CACHE_LOCATION}"
+else
+    # This is the multi-arch build that we should cache and use later
+    CACHE="--cache-to=type=local,dest=${CACHE_LOCATION}"
+fi
+
+docker buildx build \
+    $CACHE \
+    --platform "${PLATFORMS}" \
+    --progress=plain \
+    --build-arg kafka_version=$KAFKA_VERSION \
+    --build-arg scala_version=$TRAVIS_SCALA_VERSION \
+    --build-arg vcs_ref=$TRAVIS_COMMIT \
+    --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+    -t drewpc/kafka \
+    $EXTRA_BUILDX_ARGS \
+    .

--- a/docker_buildx
+++ b/docker_buildx
@@ -27,6 +27,6 @@ docker buildx build \
     --build-arg scala_version=$TRAVIS_SCALA_VERSION \
     --build-arg vcs_ref=$TRAVIS_COMMIT \
     --build-arg build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-    -t drewpc/kafka \
+    -t wurstmeister/kafka \
     $EXTRA_BUILDX_ARGS \
     .

--- a/docker_push
+++ b/docker_push
@@ -10,5 +10,6 @@ fi
 
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 TARGET="$BASE_IMAGE:$IMAGE_VERSION"
-docker tag "$BASE_IMAGE" "$TARGET"
-docker push "$TARGET"
+bash docker_buildx \
+    -t "$TARGET" \
+    --push


### PR DESCRIPTION
- Fixes #675 by enabling multi-architecture builds in Travis CI.
- Add back the Scala/Kafka versions that match the README "Tags and releases" section to ensure we get multi-architecture builds for those releases as well.
- Fixed the link target for Travis CI in the build icon.

The Travis CI builds [were tested](https://app.travis-ci.com/github/drewpc/kafka-docker/builds/241747093) and new docker images pushed to [my personal Docker Hub account](https://hub.docker.com/repository/docker/drewpc/kafka).