### PR TITLE
drop support for versions < 2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,6 @@ env:
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
   include:
-  - scala: 2.10
-    env: KAFKA_VERSION=0.8.2.2
-  - scala: 2.11
-    env: KAFKA_VERSION=0.9.0.1
-  - scala: 2.11
-    env: KAFKA_VERSION=0.10.2.2
-  - scala: 2.11
-    env: KAFKA_VERSION=0.11.0.3
-  - scala: 2.11
-    env: KAFKA_VERSION=1.0.2
-  - scala: 2.11
-    env: KAFKA_VERSION=1.1.1
   - scala: 2.12
     env: KAFKA_VERSION=2.0.1
   - scala: 2.12
@@ -36,11 +24,11 @@ matrix:
   - scala: 2.12
     env: KAFKA_VERSION=2.4.1
   - scala: 2.12
-    env: KAFKA_VERSION=2.5.0
+    env: KAFKA_VERSION=2.5.1
   - scala: 2.13
-    env: KAFKA_VERSION=2.6.0
+    env: KAFKA_VERSION=2.6.3
   - scala: 2.13
-    env: KAFKA_VERSION=2.7.1
+    env: KAFKA_VERSION=2.7.2
   - scala: 2.13
     env: KAFKA_VERSION=2.8.1
 

--- a/README.md
+++ b/README.md
@@ -15,23 +15,11 @@ The image is available directly from [Docker Hub](https://hub.docker.com/r/wurst
 Tags and releases
 -----------------
 
-All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). Available tags are:
+All versions of the image are built from the same set of scripts with only minor variations (i.e. certain features are not supported on older versions). The version format mirrors the Kafka format, `<scala version>-<kafka version>`. Initially, all images are built with the recommended version of scala documented on [http://kafka.apache.org/downloads](http://kafka.apache.org/downloads). To list all available tags:
 
-- `2.13-2.8.1`
-- `2.13-2.7.1`
-- `2.13-2.6.0`
-- `2.12-2.5.0`
-- `2.12-2.4.1`
-- `2.12-2.3.1`
-- `2.12-2.2.2`
-- `2.12-2.1.1`
-- `2.12-2.0.1`
-- `2.11-1.1.1`
-- `2.11-1.0.2`
-- `2.11-0.11.0.3`
-- `2.11-0.10.2.2`
-- `2.11-0.9.0.1`
-- `2.10-0.8.2.2`
+```
+curl -s https://registry.hub.docker.com/v2/repositories/wurstmeister/kafka/tags\?page_size\=1024 | jq -r '.results[].name' | sort -u | egrep '\d.\d{2}-.*'
+```
 
 Everytime the image is updated, all tags will be pushed with the latest updates. This should allow for greater consistency across tags, as well as any security updates that have been made to the base image.
 


### PR DESCRIPTION
* update minor versions to latest available
* included script to retrieve available tags in readme