### PR TITLE
Updating base image to tag 8u332-8.62.0.19 for security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:8u292-8.54.0.21
+FROM azul/zulu-openjdk-alpine:8u332-8.62.0.19
 
 ARG kafka_version=2.8.1
 ARG scala_version=2.13


### PR DESCRIPTION
The current base image uses Alpine v3.4.6. This version of Alpine can't update all of its packages if they are suffering from vulnerabilities. Updating to `azul/zulu-openjdk-alpine:8u332-8.62.0.19` will allow it to use Alpine v3.15 without affecting the rest of functionality, and allowing Dockerfiles based on this kafka-docker image to upgrade their packages to patched versions without affecting this one.