### PR TITLE
Adjust docker-compose single example

### DIFF
--- a/docker-compose-single-broker.yml
+++ b/docker-compose-single-broker.yml
@@ -9,7 +9,8 @@ services:
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.99.100
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092
       KAFKA_CREATE_TOPICS: "test:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:


### PR DESCRIPTION
Using KAFKA_ADVERTISED_HOST_NAME is now deprecated: https://kafka.apache.org/0110/documentation.html#brokerconfigs