### PR TITLE
Dockerfile - apply apt upgrade, not just simulate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY download-kafka.sh start-kafka.sh broker-list.sh create-topics.sh versions.s
 
 RUN set -eux ; \
     apt-get update ; \
-    apt-get upgrade -s ; \
+    apt-get upgrade -y ; \
     apt-get install -y --no-install-recommends jq net-tools curl wget ; \
 ### BEGIN docker for CI tests
     apt-get install -y --no-install-recommends gnupg lsb-release ; \


### PR DESCRIPTION
To consume Debian updates, we need to apply them using `-y` in `apt-get upgrade`, not just simulate them using `-s ` (`-s, --simulate`, see https://linux.die.net/man/8/apt-get).

It looks like just a typo, the `s` and `y` keys being so close on the keyboard.
Or is it set to simulate intentionally?