### PR TITLE
Bump Kafka version from 2.8.1 to 2.8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 # This version will be also tagged as 'latest'
 env:
   global:
-    - LATEST="2.13-2.8.1"
+    - LATEST="2.13-2.8.2"
 
 # Build recommended versions based on: http://kafka.apache.org/downloads
 matrix:
@@ -28,7 +28,7 @@ matrix:
   - scala: 2.13
     env: KAFKA_VERSION=2.7.2
   - scala: 2.13
-    env: KAFKA_VERSION=2.8.1
+    env: KAFKA_VERSION=2.8.2
 
 # Upgrade Docker Engine so we can use buildx
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 Kafka features are not tied to a specific kafka-docker version (ideally all changes will be merged into all branches). Therefore, this changelog will track changes to the image by date.
 
+22-Sep-2022
+----------
+
+-	Add support for Kafka `2.8.2`
+
+19-July
 09-Apr-2022
 ----------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-jre-slim
 
-ARG kafka_version=2.8.1
+ARG kafka_version=2.8.2
 ARG scala_version=2.13
 ARG vcs_ref=unspecified
 ARG build_date=unspecified

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
-       - KAFKA_VERSION=${KAFKA_VERSION-2.8.1}
+       - KAFKA_VERSION=${KAFKA_VERSION-2.8.2}
     volumes:
       - .:/tests
     working_dir: /tests


### PR DESCRIPTION
Kafka 2.8.1 is vulnerable to CVE-2022-34917.
A patch is available with Kafka 2.8.2, see https://kafka.apache.org/cve-list.

So I basically just had to replace the version number in some places, similar to what was done in PR#688 when adding 2.8.1, and as described in https://github.com/wurstmeister/kafka-docker/wiki/ReleaseProcess.
Testing locally shows no issues or different behavior.

Let me know your thoughts. Thanks.

@wurstmeister 