### PR TITLE
replace deprecated openjdk image with eclipse-temurin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-jammy
 
 ARG kafka_version=2.8.1
 ARG scala_version=2.13


### PR DESCRIPTION
This image is available for all platforms: https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=11-jre-jammy