### PR TITLE
Bump Kafka version to 3.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM openjdk:11-jre-slim
 
-ARG kafka_version=2.8.1
+ARG kafka_version=3.7.1
 ARG scala_version=2.13
 ARG vcs_ref=unspecified
 ARG build_date=unspecified
 
 LABEL org.label-schema.name="kafka" \
-      org.label-schema.description="Apache Kafka" \
-      org.label-schema.build-date="${build_date}" \
-      org.label-schema.vcs-url="https://github.com/wurstmeister/kafka-docker" \
-      org.label-schema.vcs-ref="${vcs_ref}" \
-      org.label-schema.version="${scala_version}_${kafka_version}" \
-      org.label-schema.schema-version="1.0" \
-      maintainer="wurstmeister"
+    org.label-schema.description="Apache Kafka" \
+    org.label-schema.build-date="${build_date}" \
+    org.label-schema.vcs-url="https://github.com/wurstmeister/kafka-docker" \
+    org.label-schema.vcs-ref="${vcs_ref}" \
+    org.label-schema.version="${scala_version}_${kafka_version}" \
+    org.label-schema.schema-version="1.0" \
+    maintainer="wurstmeister"
 
 ENV KAFKA_VERSION=$kafka_version \
     SCALA_VERSION=$scala_version \
@@ -26,22 +26,22 @@ RUN set -eux ; \
     apt-get update ; \
     apt-get upgrade -y ; \
     apt-get install -y --no-install-recommends jq net-tools curl wget ; \
-### BEGIN docker for CI tests
+    ### BEGIN docker for CI tests
     apt-get install -y --no-install-recommends gnupg lsb-release ; \
-	curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg ; \
-	echo \
-  		"deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
-  		$(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null ; \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg ; \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null ; \
     apt-get update ; \
     apt-get install -y --no-install-recommends docker-ce-cli ; \
     apt remove -y gnupg lsb-release ; \
     apt clean ; \
     apt autoremove -y ; \
     apt -f install ; \
-### END docker for CI tests
-### BEGIN other for CI tests
+    ### END docker for CI tests
+    ### BEGIN other for CI tests
     apt-get install -y --no-install-recommends netcat ; \
-### END other for CI tests
+    ### END other for CI tests
     chmod a+x /tmp2/*.sh ; \
     mv /tmp2/start-kafka.sh /tmp2/broker-list.sh /tmp2/create-topics.sh /tmp2/versions.sh /usr/bin ; \
     sync ; \


### PR DESCRIPTION
Update the Dockerfile to use the latest Kafka version, 3.7.1. This includes improvements and bug fixes.
Running vulnerability scan here are founds:
Before upgrade:

- Total vulnerabilities: 15 (10 High, 5 Critical)
- Some of the vulnerabilities found:
  - CVE-2020-36518: Denial of service via a large depth of nested objects in jackson-databind.
  - CVE-2019-17571: Deserialization of untrusted data in log4j, among others.

![before_upgrade](https://github.com/user-attachments/assets/c9f24b60-5697-4ed2-9f08-5c23e708fd6e)

After upgrade:

- Total vulnerabilities: 1 (1 High)
- Remaining vulnerability:
  - CVE-2024-7254: StackOverflow vulnerability in Protocol Buffers.

![after_upgrade](https://github.com/user-attachments/assets/1562aa02-ff86-41e3-bc16-a2b40e40b06a)

